### PR TITLE
feat: implement JWKS endpoint

### DIFF
--- a/apps/registry/src/routes/.well-known/jwks.json/+server.spec.ts
+++ b/apps/registry/src/routes/.well-known/jwks.json/+server.spec.ts
@@ -1,0 +1,98 @@
+// Test JWKS endpoint
+/// <reference types="@cloudflare/workers-types" />
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GET } from './+server.js';
+import type { JWKS } from '@polyphony/shared/crypto';
+
+// Mock D1 database
+const mockDb = {
+	prepare: (sql: string) => ({
+		all: async () => ({ results: [] })
+	})
+} as unknown as D1Database;
+
+describe('GET /.well-known/jwks.json', () => {
+	it('should return valid JWKS JSON structure', async () => {
+		const response = await GET({
+			platform: { env: { DB: mockDb, API_KEY: 'test-key' } }
+		} as any);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toBe('application/json');
+
+		const data = (await response.json()) as JWKS;
+		expect(data).toHaveProperty('keys');
+		expect(Array.isArray(data.keys)).toBe(true);
+	});
+
+	it('should include Cache-Control header', async () => {
+		const response = await GET({
+			platform: { env: { DB: mockDb, API_KEY: 'test-key' } }
+		} as any);
+
+		const cacheControl = response.headers.get('cache-control');
+		expect(cacheControl).toContain('max-age=3600');
+		expect(cacheControl).toContain('public');
+	});
+
+	it('should return keys in JWKS format', async () => {
+		// Mock database with a key
+		const mockDbWithKey = {
+			prepare: (sql: string) => ({
+				all: async () => ({
+					results: [
+						{
+							id: 'key-1',
+							algorithm: 'EdDSA',
+							public_key: `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
+-----END PUBLIC KEY-----`
+						}
+					]
+				})
+			})
+		} as unknown as D1Database;
+
+		const response = await GET({
+			platform: { env: { DB: mockDbWithKey, API_KEY: 'test-key' } }
+		} as any);
+
+		const data = (await response.json()) as JWKS;
+		expect(data.keys).toHaveLength(1);
+
+		const key = data.keys[0];
+		expect(key.kty).toBe('OKP');
+		expect(key.crv).toBe('Ed25519');
+		expect(key.use).toBe('sig');
+		expect(key.alg).toBe('EdDSA');
+		expect(key.kid).toBe('key-1');
+		expect(key.x).toBeTruthy(); // base64url-encoded public key
+	});
+
+	it('should only include non-revoked keys', async () => {
+		const mockDbWithKeys = {
+			prepare: (sql: string) => ({
+				all: async () => ({
+					results: [
+						{
+							id: 'key-active',
+							algorithm: 'EdDSA',
+							public_key: `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
+-----END PUBLIC KEY-----`
+						}
+						// key-revoked should NOT be in results (filtered by SQL)
+					]
+				})
+			})
+		} as unknown as D1Database;
+
+		const response = await GET({
+			platform: { env: { DB: mockDbWithKeys, API_KEY: 'test-key' } }
+		} as any);
+
+		const data = (await response.json()) as JWKS;
+		expect(data.keys).toHaveLength(1);
+		expect(data.keys[0].kid).toBe('key-active');
+	});
+});

--- a/apps/registry/src/routes/.well-known/jwks.json/+server.ts
+++ b/apps/registry/src/routes/.well-known/jwks.json/+server.ts
@@ -1,0 +1,33 @@
+// JWKS endpoint - public keys for JWT verification
+// GET /.well-known/jwks.json
+/// <reference types="@cloudflare/workers-types" />
+import { json } from '@sveltejs/kit';
+import { pemToJwk, type JWKS } from '@polyphony/shared/crypto';
+
+interface CloudflarePlatform {
+	env: { DB: D1Database };
+}
+
+export const GET = async ({ platform }: { platform?: CloudflarePlatform }) => {
+	if (!platform) throw new Error('Platform not available');
+	const db = platform.env.DB;
+
+	// Fetch all non-revoked signing keys
+	const { results } = await db
+		.prepare('SELECT id, public_key FROM signing_keys WHERE revoked_at IS NULL')
+		.all();
+
+	// Convert each key to JWK format
+	const keys = await Promise.all(
+		results.map((row: any) => pemToJwk(row.public_key, row.id))
+	);
+
+	const jwks: JWKS = { keys };
+
+	return json(jwks, {
+		headers: {
+			'Cache-Control': 'public, max-age=3600',
+			'Content-Type': 'application/json'
+		}
+	});
+};

--- a/packages/shared/src/crypto/index.ts
+++ b/packages/shared/src/crypto/index.ts
@@ -1,2 +1,3 @@
 // Crypto utilities - JWT signing and verification
 export { signToken, verifyToken, type AuthToken } from './jwt.js';
+export { pemToJwk, type JWK, type JWKS } from './jwks.js';

--- a/packages/shared/src/crypto/jwks.spec.ts
+++ b/packages/shared/src/crypto/jwks.spec.ts
@@ -1,0 +1,39 @@
+// Test JWKS conversion
+import { describe, it, expect, beforeAll } from 'vitest';
+import { pemToJwk } from './jwks.js';
+import { generateKeyPair, exportSPKI } from 'jose';
+
+let testPublicKey: string;
+
+beforeAll(async () => {
+	// Generate a test Ed25519 keypair
+	const { publicKey } = await generateKeyPair('EdDSA', { extractable: true });
+	testPublicKey = await exportSPKI(publicKey);
+});
+
+describe('pemToJwk', () => {
+	it('should convert PEM public key to JWK format', async () => {
+		const jwk = await pemToJwk(testPublicKey, 'test-key-123');
+
+		expect(jwk).toMatchObject({
+			kty: 'OKP',
+			crv: 'Ed25519',
+			use: 'sig',
+			alg: 'EdDSA',
+			kid: 'test-key-123'
+		});
+		expect(jwk.x).toBeTruthy();
+		expect(typeof jwk.x).toBe('string');
+	});
+
+	it('should use provided key ID', async () => {
+		const jwk = await pemToJwk(testPublicKey, 'custom-key-id');
+		expect(jwk.kid).toBe('custom-key-id');
+	});
+
+	it('should produce base64url-encoded x value', async () => {
+		const jwk = await pemToJwk(testPublicKey, 'test-key');
+		// base64url should not contain +, /, or =
+		expect(jwk.x).not.toMatch(/[+/=]/);
+	});
+});

--- a/packages/shared/src/crypto/jwks.ts
+++ b/packages/shared/src/crypto/jwks.ts
@@ -1,0 +1,38 @@
+// Convert Ed25519 PEM keys to JWKS format
+import { importSPKI, exportJWK } from 'jose';
+
+export interface JWK {
+	kty: 'OKP';
+	crv: 'Ed25519';
+	x: string; // base64url-encoded public key
+	kid: string; // key ID
+	use: 'sig';
+	alg: 'EdDSA';
+}
+
+export interface JWKS {
+	keys: JWK[];
+}
+
+/**
+ * Convert Ed25519 PEM public key to JWK format
+ * @param publicKeyPem - PEM-formatted Ed25519 public key
+ * @param keyId - Key identifier (kid)
+ * @returns JWK object
+ */
+export async function pemToJwk(publicKeyPem: string, keyId: string): Promise<JWK> {
+	// Import the PEM key
+	const publicKey = await importSPKI(publicKeyPem, 'EdDSA');
+
+	// Export as JWK
+	const jwk = await exportJWK(publicKey);
+
+	return {
+		kty: 'OKP',
+		crv: 'Ed25519',
+		x: jwk.x!,
+		kid: keyId,
+		use: 'sig',
+		alg: 'EdDSA'
+	};
+}


### PR DESCRIPTION
Implements #15

## Changes

- ✅ Created `GET /.well-known/jwks.json` endpoint
- ✅ Added `pemToJwk()` helper to convert Ed25519 PEM keys to JWKS format
- ✅ Fetch non-revoked signing keys from D1 database
- ✅ Return proper JWKS JSON structure with Cache-Control headers (3600s)
- ✅ Added comprehensive test suite (7 tests total)
- ✅ Exported JWKS types from `@polyphony/shared`

## Endpoint Response

```json
{
  "keys": [
    {
      "kty": "OKP",
      "crv": "Ed25519",
      "x": "<base64url-encoded-public-key>",
      "kid": "<key-id>",
      "use": "sig",
      "alg": "EdDSA"
    }
  ]
}
```

## Test Results

All 15 tests passing:
- 3 JWKS conversion tests (shared package)
- 4 endpoint tests (registry app)
- 6 JWT tests (from #14)
- 2 setup tests

## TDD Workflow

✅ Red: Wrote failing tests first
✅ Green: Implemented endpoint and helpers to pass tests
✅ Refactor: Clean TypeScript with proper typing
✅ Verified: No TypeScript errors before commit

Closes #15