### PR TITLE
feat: implement Google OAuth flow

### DIFF
--- a/apps/registry/src/routes/auth/+server.spec.ts
+++ b/apps/registry/src/routes/auth/+server.spec.ts
@@ -1,0 +1,111 @@
+// Test OAuth initiation endpoint
+/// <reference types="@cloudflare/workers-types" />
+import { describe, it, expect } from 'vitest';
+import { GET } from './+server.js';
+import type { JWKS } from '@polyphony/shared/crypto';
+
+// Mock D1 database
+const createMockDb = (vaultExists: boolean, callback?: string) => ({
+	prepare: (sql: string) => ({
+		bind: () => ({
+			first: async () =>
+				vaultExists
+					? {
+							id: 'vault-test-id',
+							name: 'Test Vault',
+							callback_url: callback || 'https://vault.example.com/callback',
+							active: 1
+						}
+					: null
+		})
+	})
+} as unknown as D1Database);
+
+describe('GET /auth', () => {
+	it('should reject missing vault_id parameter', async () => {
+		const url = new URL('http://localhost/auth');
+		const response = await GET({
+			url,
+			platform: { env: { DB: createMockDb(false), API_KEY: 'test' } }
+		} as any);
+
+		expect(response.status).toBe(400);
+		const data = await response.json();
+		expect(data.error).toContain('vault_id');
+	});
+
+	it('should reject missing callback parameter', async () => {
+		const url = new URL('http://localhost/auth?vault_id=vault-test-id');
+		const response = await GET({
+			url,
+			platform: { env: { DB: createMockDb(true), API_KEY: 'test' } }
+		} as any);
+
+		expect(response.status).toBe(400);
+		const data = await response.json();
+		expect(data.error).toContain('callback');
+	});
+
+	it('should reject unregistered vault_id', async () => {
+		const url = new URL(
+			'http://localhost/auth?vault_id=unknown-vault&callback=https://vault.example.com/callback'
+		);
+		const response = await GET({
+			url,
+			platform: { env: { DB: createMockDb(false), API_KEY: 'test' } }
+		} as any);
+
+		expect(response.status).toBe(400);
+		const data = await response.json();
+		expect(data.error).toContain('not registered');
+	});
+
+	it('should reject mismatched callback URL', async () => {
+		const url = new URL(
+			'http://localhost/auth?vault_id=vault-test-id&callback=https://evil.com/callback'
+		);
+		const response = await GET({
+			url,
+			platform: {
+				env: {
+					DB: createMockDb(true, 'https://vault.example.com/callback'),
+					API_KEY: 'test'
+				}
+			}
+		} as any);
+
+		expect(response.status).toBe(400);
+		const data = await response.json();
+		expect(data.error).toContain('callback URL');
+	});
+
+	it('should redirect to Google OAuth with valid parameters', async () => {
+		const url = new URL(
+			'http://localhost/auth?vault_id=vault-test-id&callback=https://vault.example.com/callback'
+		);
+		
+		try {
+			await GET({
+				url,
+				platform: {
+					env: {
+						DB: createMockDb(true, 'https://vault.example.com/callback'),
+						API_KEY: 'test',
+						GOOGLE_CLIENT_ID: 'test-client-id'
+					}
+				}
+			} as any);
+			
+			// Should not reach here - redirect throws
+			expect(true).toBe(false);
+		} catch (redirect: any) {
+			// SvelteKit redirect throws an error
+			expect(redirect.status).toBe(302);
+			const location = redirect.location;
+			expect(location).toContain('accounts.google.com/o/oauth2/v2/auth');
+			expect(location).toContain('client_id=test-client-id');
+			expect(location).toContain('response_type=code');
+			expect(location).toContain('scope=openid+email+profile');
+		}
+	});
+});

--- a/apps/registry/src/routes/auth/+server.ts
+++ b/apps/registry/src/routes/auth/+server.ts
@@ -1,0 +1,50 @@
+// OAuth initiation endpoint
+// GET /auth?vault_id=xxx&callback=https://vault.../callback
+/// <reference types="@cloudflare/workers-types" />
+import { json, redirect } from '@sveltejs/kit';
+
+interface CloudflarePlatform {
+	env: { DB: D1Database; API_KEY: string; GOOGLE_CLIENT_ID: string };
+}
+
+export const GET = async ({ url, platform }: { url: URL; platform?: CloudflarePlatform }) => {
+	if (!platform) throw new Error('Platform not available');
+
+	const vaultId = url.searchParams.get('vault_id');
+	const callbackUrl = url.searchParams.get('callback');
+
+	// Validate required parameters
+	if (!vaultId) {
+		return json({ error: 'Missing vault_id parameter' }, { status: 400 });
+	}
+
+	if (!callbackUrl) {
+		return json({ error: 'Missing callback parameter' }, { status: 400 });
+	}
+
+	// Verify vault exists and is active
+	const vault = await platform.env.DB.prepare(
+		'SELECT id, callback_url, active FROM vaults WHERE id = ? AND active = 1'
+	)
+		.bind(vaultId)
+		.first();
+
+	if (!vault) {
+		return json({ error: 'Vault not registered' }, { status: 400 });
+	}
+
+	// Verify callback URL matches registered callback
+	if (vault.callback_url !== callbackUrl) {
+		return json({ error: 'Invalid callback URL' }, { status: 400 });
+	}
+
+	// Build Google OAuth URL
+	const googleAuthUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+	googleAuthUrl.searchParams.set('client_id', platform.env.GOOGLE_CLIENT_ID);
+	googleAuthUrl.searchParams.set('redirect_uri', `${url.origin}/auth/callback`);
+	googleAuthUrl.searchParams.set('response_type', 'code');
+	googleAuthUrl.searchParams.set('scope', 'openid email profile');
+	googleAuthUrl.searchParams.set('state', JSON.stringify({ vaultId, callbackUrl }));
+
+	return redirect(302, googleAuthUrl.toString());
+};

--- a/apps/registry/src/routes/auth/callback/+server.spec.ts
+++ b/apps/registry/src/routes/auth/callback/+server.spec.ts
@@ -1,0 +1,132 @@
+// Test OAuth callback endpoint
+/// <reference types="@cloudflare/workers-types" />
+import { describe, it, expect, vi } from 'vitest';
+import { GET } from './+server.js';
+
+// Mock fetch for Google token exchange
+const createMockFetch = (success: boolean = true) => {
+	return vi.fn(async (url: string) => {
+		if (url.includes('oauth2.googleapis.com/token')) {
+			if (!success) {
+				return new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 });
+			}
+			return new Response(
+				JSON.stringify({
+					access_token: 'mock-access-token',
+					id_token: 'mock-id-token'
+				}),
+				{ status: 200 }
+			);
+		}
+		if (url.includes('www.googleapis.com/oauth2/v3/userinfo')) {
+			return new Response(
+				JSON.stringify({
+					email: 'user@example.com',
+					name: 'Test User',
+					picture: 'https://example.com/photo.jpg'
+				}),
+				{ status: 200 }
+			);
+		}
+		return new Response('Not found', { status: 404 });
+	});
+};
+
+// Mock D1 database with signing key
+const createMockDb = () => ({
+	prepare: (sql: string) => ({
+		first: async () => ({
+			id: 'key-1',
+			private_key: `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIHcHbQpzGKV9PBbBclGyZkXfTC+H68CZKrF3+6UduSwq
+-----END PRIVATE KEY-----`,
+			public_key: `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
+-----END PUBLIC KEY-----`
+		})
+	})
+} as unknown as D1Database);
+
+describe('GET /auth/callback', () => {
+	it('should reject missing code parameter', async () => {
+		const url = new URL('http://localhost/auth/callback?state={}');
+		const response = await GET({
+			url,
+			platform: { env: { DB: createMockDb(), API_KEY: 'test' } },
+			fetch: createMockFetch()
+		} as any);
+
+		expect(response.status).toBe(400);
+		const text = await response.text();
+		expect(text).toContain('Missing authorization code');
+	});
+
+	it('should reject missing state parameter', async () => {
+		const url = new URL('http://localhost/auth/callback?code=test-code');
+		const response = await GET({
+			url,
+			platform: { env: { DB: createMockDb(), API_KEY: 'test' } },
+			fetch: createMockFetch()
+		} as any);
+
+		expect(response.status).toBe(400);
+		const text = await response.text();
+		expect(text).toContain('Missing state');
+	});
+
+	it('should exchange code for tokens and redirect with JWT', async () => {
+		const state = JSON.stringify({
+			vaultId: 'vault-test-id',
+			callbackUrl: 'https://vault.example.com/callback'
+		});
+		const url = new URL(`http://localhost/auth/callback?code=test-code&state=${state}`);
+		
+		try {
+			await GET({
+				url,
+				platform: {
+					env: {
+						DB: createMockDb(),
+						API_KEY: 'test',
+						GOOGLE_CLIENT_ID: 'test-client-id',
+						GOOGLE_CLIENT_SECRET: 'test-client-secret'
+					}
+				},
+				fetch: createMockFetch(true)
+			} as any);
+			
+			// Should not reach here - redirect throws
+			expect(true).toBe(false);
+		} catch (redirect: any) {
+			// SvelteKit redirect throws an error
+			expect(redirect.status).toBe(302);
+			expect(redirect.location).toContain('https://vault.example.com/callback');
+			expect(redirect.location).toContain('token=');
+		}
+	});
+
+	it('should handle Google token exchange failure', async () => {
+		const state = JSON.stringify({
+			vaultId: 'vault-test-id',
+			callbackUrl: 'https://vault.example.com/callback'
+		});
+		const url = new URL(`http://localhost/auth/callback?code=bad-code&state=${state}`);
+		
+		const response = await GET({
+			url,
+			platform: {
+				env: {
+					DB: createMockDb(),
+					API_KEY: 'test',
+					GOOGLE_CLIENT_ID: 'test-client-id',
+					GOOGLE_CLIENT_SECRET: 'test-client-secret'
+				}
+			},
+			fetch: createMockFetch(false)
+		} as any);
+
+		expect(response.status).toBe(400);
+		const text = await response.text();
+		expect(text).toContain('Failed to exchange');
+	});
+});

--- a/apps/registry/src/routes/auth/callback/+server.ts
+++ b/apps/registry/src/routes/auth/callback/+server.ts
@@ -1,0 +1,105 @@
+// OAuth callback endpoint
+// GET /auth/callback?code=xxx&state=xxx
+/// <reference types="@cloudflare/workers-types" />
+import { redirect } from '@sveltejs/kit';
+import { signToken } from '@polyphony/shared/crypto';
+import { nanoid } from 'nanoid';
+
+interface CloudflarePlatform {
+	env: {
+		DB: D1Database;
+		API_KEY: string;
+		GOOGLE_CLIENT_ID: string;
+		GOOGLE_CLIENT_SECRET: string;
+	};
+}
+
+interface GoogleTokenResponse {
+	access_token: string;
+	id_token: string;
+}
+
+interface GoogleUserInfo {
+	email: string;
+	name?: string;
+	picture?: string;
+}
+
+export const GET = async ({
+	url,
+	platform,
+	fetch
+}: {
+	url: URL;
+	platform?: CloudflarePlatform;
+	fetch: typeof globalThis.fetch;
+}) => {
+	if (!platform) throw new Error('Platform not available');
+
+	const code = url.searchParams.get('code');
+	const stateParam = url.searchParams.get('state');
+
+	if (!code) {
+		return new Response('Missing authorization code', { status: 400 });
+	}
+
+	if (!stateParam) {
+		return new Response('Missing state parameter', { status: 400 });
+	}
+
+	const state = JSON.parse(stateParam) as { vaultId: string; callbackUrl: string };
+
+	// Exchange authorization code for tokens
+	const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({
+			code,
+			client_id: platform.env.GOOGLE_CLIENT_ID,
+			client_secret: platform.env.GOOGLE_CLIENT_SECRET,
+			redirect_uri: `${url.origin}/auth/callback`,
+			grant_type: 'authorization_code'
+		})
+	});
+
+	if (!tokenResponse.ok) {
+		return new Response('Failed to exchange authorization code', { status: 400 });
+	}
+
+	const tokens = (await tokenResponse.json()) as GoogleTokenResponse;
+
+	// Fetch user info from Google
+	const userInfoResponse = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
+		headers: { Authorization: `Bearer ${tokens.access_token}` }
+	});
+
+	const userInfo = (await userInfoResponse.json()) as GoogleUserInfo;
+
+	// Fetch active signing key
+	const signingKey = await platform.env.DB.prepare(
+		'SELECT id, private_key FROM signing_keys WHERE revoked_at IS NULL ORDER BY created_at DESC LIMIT 1'
+	).first();
+
+	if (!signingKey) {
+		return new Response('No active signing key', { status: 500 });
+	}
+
+	// Create JWT
+	const token = await signToken(
+		{
+			iss: 'https://registry.polyphony.app',
+			sub: userInfo.email,
+			aud: state.vaultId,
+			nonce: nanoid(),
+			name: userInfo.name,
+			picture: userInfo.picture
+		},
+		signingKey.private_key as string
+	);
+
+	// Redirect to vault callback with token
+	const callbackUrl = new URL(state.callbackUrl);
+	callbackUrl.searchParams.set('token', token);
+
+	return redirect(302, callbackUrl.toString());
+};


### PR DESCRIPTION
Implements #16

## Changes

- ✅ Created `GET /auth` endpoint to initiate OAuth flow
- ✅ Validate vault_id and callback URL against registered vaults
- ✅ Redirect to Google OAuth with state preservation
- ✅ Created `GET /auth/callback` endpoint to handle OAuth response
- ✅ Exchange authorization code for Google tokens
- ✅ Fetch user info (email, name, picture) from Google
- ✅ Generate and sign JWT with user claims
- ✅ Redirect to vault callback with token
- ✅ Comprehensive test suite (9 tests total)

## OAuth Flow

1. Vault redirects to `/auth?vault_id=xxx&callback=https://vault.../cb`
2. Registry validates vault_id and callback URL
3. Registry redirects to Google OAuth with state
4. User authenticates with Google
5. Google returns with auth code to `/auth/callback`
6. Registry exchanges code for tokens
7. Registry fetches user info from Google
8. Registry creates signed JWT with user claims
9. Registry redirects to vault callback with token

## Test Results

All 24 tests passing:
- 5 auth initiation tests (parameter validation + OAuth redirect)
- 4 OAuth callback tests (token exchange + JWT creation)
- 9 shared package tests (from #14, #15)
- 4 JWKS endpoint tests (from #15)
- 2 setup tests

## Environment Variables Required

```toml
GOOGLE_CLIENT_ID = "..."
GOOGLE_CLIENT_SECRET = "..."
```

## TDD Workflow

✅ Red: Wrote failing tests first
✅ Green: Implemented endpoints to pass tests
✅ Refactor: Clean TypeScript with proper error handling
✅ Verified: All tests passing before commit

Closes #16