### PR TITLE
feat: implement Vault registration API

### DIFF
--- a/apps/registry/src/routes/api/vaults/+server.spec.ts
+++ b/apps/registry/src/routes/api/vaults/+server.spec.ts
@@ -1,0 +1,202 @@
+// Test Vault registration API
+/// <reference types="@cloudflare/workers-types" />
+import { describe, it, expect } from 'vitest';
+import { POST, GET } from './+server.js';
+
+// Mock D1 database
+const createMockDb = (existingVaultName?: string) => ({
+	prepare: (sql: string) => ({
+		bind: (...args: any[]) => ({
+			first: async () => {
+				if (sql.includes('SELECT') && sql.includes('name')) {
+					return existingVaultName ? { name: existingVaultName } : null;
+				}
+				return null;
+			},
+			run: async () => ({ success: true })
+		}),
+		all: async () => ({ results: [] })
+	})
+} as unknown as D1Database);
+
+describe('POST /api/vaults', () => {
+	it('should reject request without API key', async () => {
+		const request = new Request('http://localhost/api/vaults', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Test Vault', callback_url: 'https://example.com/callback' })
+		});
+
+		const response = await POST({
+			request,
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(401);
+	});
+
+	it('should reject request with invalid API key', async () => {
+		const request = new Request('http://localhost/api/vaults', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-API-Key': 'wrong-key'
+			},
+			body: JSON.stringify({ name: 'Test Vault', callback_url: 'https://example.com/callback' })
+		});
+
+		const response = await POST({
+			request,
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(401);
+	});
+
+	it('should reject request without name', async () => {
+		const request = new Request('http://localhost/api/vaults', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-API-Key': 'secret'
+			},
+			body: JSON.stringify({ callback_url: 'https://example.com/callback' })
+		});
+
+		const response = await POST({
+			request,
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(400);
+		const data = await response.json();
+		expect(data.error).toContain('name');
+	});
+
+	it('should reject request without callback_url', async () => {
+		const request = new Request('http://localhost/api/vaults', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-API-Key': 'secret'
+			},
+			body: JSON.stringify({ name: 'Test Vault' })
+		});
+
+		const response = await POST({
+			request,
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(400);
+		const data = await response.json();
+		expect(data.error).toContain('callback_url');
+	});
+
+	it('should reject HTTP callback URL', async () => {
+		const request = new Request('http://localhost/api/vaults', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-API-Key': 'secret'
+			},
+			body: JSON.stringify({ name: 'Test Vault', callback_url: 'http://example.com/callback' })
+		});
+
+		const response = await POST({
+			request,
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(400);
+		const data = await response.json();
+		expect(data.error).toContain('HTTPS');
+	});
+
+	it('should reject duplicate vault name', async () => {
+		const request = new Request('http://localhost/api/vaults', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-API-Key': 'secret'
+			},
+			body: JSON.stringify({ name: 'Existing Vault', callback_url: 'https://example.com/callback' })
+		});
+
+		const response = await POST({
+			request,
+			platform: { env: { DB: createMockDb('Existing Vault'), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(409);
+		const data = await response.json();
+		expect(data.error).toContain('already exists');
+	});
+
+	it('should register new vault successfully', async () => {
+		const request = new Request('http://localhost/api/vaults', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-API-Key': 'secret'
+			},
+			body: JSON.stringify({ name: 'New Vault', callback_url: 'https://example.com/callback' })
+		});
+
+		const response = await POST({
+			request,
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(201);
+		const data = await response.json();
+		expect(data.id).toBeTruthy();
+		expect(data.name).toBe('New Vault');
+		expect(data.callback_url).toBe('https://example.com/callback');
+	});
+});
+
+describe('GET /api/vaults', () => {
+	it('should require API key', async () => {
+		const request = new Request('http://localhost/api/vaults');
+
+		const response = await GET({
+			request,
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(401);
+	});
+
+	it('should list all vaults', async () => {
+		const mockDb = {
+			prepare: (sql: string) => ({
+				all: async () => ({
+					results: [
+						{
+							id: 'vault-1',
+							name: 'Vault One',
+							callback_url: 'https://vault1.example.com/callback',
+							active: 1,
+							created_at: '2026-01-24T00:00:00Z'
+						}
+					]
+				})
+			})
+		} as unknown as D1Database;
+
+		const request = new Request('http://localhost/api/vaults', {
+			headers: { 'X-API-Key': 'secret' }
+		});
+
+		const response = await GET({
+			request,
+			platform: { env: { DB: mockDb, API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(200);
+		const data = await response.json();
+		expect(Array.isArray(data.vaults)).toBe(true);
+		expect(data.vaults).toHaveLength(1);
+	});
+});

--- a/apps/registry/src/routes/api/vaults/+server.ts
+++ b/apps/registry/src/routes/api/vaults/+server.ts
@@ -1,0 +1,84 @@
+// Vault registration API
+/// <reference types="@cloudflare/workers-types" />
+import { json } from '@sveltejs/kit';
+import { nanoid } from 'nanoid';
+
+interface CloudflarePlatform {
+	env: { DB: D1Database; API_KEY: string };
+}
+
+function checkAuth(request: Request, apiKey: string): boolean {
+	const providedKey = request.headers.get('X-API-Key');
+	return providedKey === apiKey;
+}
+
+export const POST = async ({ request, platform }: { request: Request; platform?: CloudflarePlatform }) => {
+	if (!platform) throw new Error('Platform not available');
+
+	// Check API key
+	if (!checkAuth(request, platform.env.API_KEY)) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	// Parse request body
+	const body = await request.json() as { name?: string; callback_url?: string };
+
+	// Validate required fields
+	if (!body.name) {
+		return json({ error: 'Missing required field: name' }, { status: 400 });
+	}
+
+	if (!body.callback_url) {
+		return json({ error: 'Missing required field: callback_url' }, { status: 400 });
+	}
+
+	// Validate HTTPS callback URL
+	if (!body.callback_url.startsWith('https://')) {
+		return json({ error: 'Callback URL must use HTTPS' }, { status: 400 });
+	}
+
+	// Check for duplicate name
+	const existing = await platform.env.DB.prepare('SELECT name FROM vaults WHERE name = ?')
+		.bind(body.name)
+		.first();
+
+	if (existing) {
+		return json({ error: 'Vault with this name already exists' }, { status: 409 });
+	}
+
+	// Generate vault ID
+	const vaultId = nanoid();
+
+	// Insert vault
+	await platform.env.DB.prepare(
+		'INSERT INTO vaults (id, name, callback_url, active) VALUES (?, ?, ?, 1)'
+	)
+		.bind(vaultId, body.name, body.callback_url)
+		.run();
+
+	return json(
+		{
+			id: vaultId,
+			name: body.name,
+			callback_url: body.callback_url,
+			active: true
+		},
+		{ status: 201 }
+	);
+};
+
+export const GET = async ({ request, platform }: { request: Request; platform?: CloudflarePlatform }) => {
+	if (!platform) throw new Error('Platform not available');
+
+	// Check API key
+	if (!checkAuth(request, platform.env.API_KEY)) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	// Fetch all vaults
+	const { results } = await platform.env.DB.prepare(
+		'SELECT id, name, callback_url, active, created_at FROM vaults ORDER BY created_at DESC'
+	).all();
+
+	return json({ vaults: results });
+};

--- a/apps/registry/src/routes/api/vaults/[id]/+server.spec.ts
+++ b/apps/registry/src/routes/api/vaults/[id]/+server.spec.ts
@@ -1,0 +1,152 @@
+// Test individual vault operations
+/// <reference types="@cloudflare/workers-types" />
+import { describe, it, expect } from 'vitest';
+import { GET, PUT, DELETE } from './+server.js';
+
+// Mock D1 database
+const createMockDb = (vaultExists: boolean = true) => ({
+	prepare: (sql: string) => ({
+		bind: (...args: any[]) => ({
+			first: async () => {
+				if (!vaultExists) return null;
+				return {
+					id: 'vault-test-id',
+					name: 'Test Vault',
+					callback_url: 'https://example.com/callback',
+					active: 1,
+					created_at: '2026-01-24T00:00:00Z'
+				};
+			},
+			run: async () => ({ success: true })
+		})
+	})
+} as unknown as D1Database);
+
+describe('GET /api/vaults/[id]', () => {
+	it('should require API key', async () => {
+		const request = new Request('http://localhost/api/vaults/vault-test-id');
+
+		const response = await GET({
+			request,
+			params: { id: 'vault-test-id' },
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(401);
+	});
+
+	it('should return 404 for non-existent vault', async () => {
+		const request = new Request('http://localhost/api/vaults/unknown-id', {
+			headers: { 'X-API-Key': 'secret' }
+		});
+
+		const response = await GET({
+			request,
+			params: { id: 'unknown-id' },
+			platform: { env: { DB: createMockDb(false), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(404);
+	});
+
+	it('should return vault details', async () => {
+		const request = new Request('http://localhost/api/vaults/vault-test-id', {
+			headers: { 'X-API-Key': 'secret' }
+		});
+
+		const response = await GET({
+			request,
+			params: { id: 'vault-test-id' },
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(200);
+		const data = await response.json();
+		expect(data.id).toBe('vault-test-id');
+		expect(data.name).toBe('Test Vault');
+	});
+});
+
+describe('PUT /api/vaults/[id]', () => {
+	it('should require API key', async () => {
+		const request = new Request('http://localhost/api/vaults/vault-test-id', {
+			method: 'PUT',
+			body: JSON.stringify({ callback_url: 'https://new.example.com/callback' })
+		});
+
+		const response = await PUT({
+			request,
+			params: { id: 'vault-test-id' },
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(401);
+	});
+
+	it('should reject HTTP callback URL', async () => {
+		const request = new Request('http://localhost/api/vaults/vault-test-id', {
+			method: 'PUT',
+			headers: { 'X-API-Key': 'secret' },
+			body: JSON.stringify({ callback_url: 'http://new.example.com/callback' })
+		});
+
+		const response = await PUT({
+			request,
+			params: { id: 'vault-test-id' },
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(400);
+		const data = await response.json();
+		expect(data.error).toContain('HTTPS');
+	});
+
+	it('should update callback URL', async () => {
+		const request = new Request('http://localhost/api/vaults/vault-test-id', {
+			method: 'PUT',
+			headers: { 'X-API-Key': 'secret' },
+			body: JSON.stringify({ callback_url: 'https://new.example.com/callback' })
+		});
+
+		const response = await PUT({
+			request,
+			params: { id: 'vault-test-id' },
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(200);
+		const data = await response.json();
+		expect(data.id).toBe('vault-test-id');
+	});
+});
+
+describe('DELETE /api/vaults/[id]', () => {
+	it('should require API key', async () => {
+		const request = new Request('http://localhost/api/vaults/vault-test-id', {
+			method: 'DELETE'
+		});
+
+		const response = await DELETE({
+			request,
+			params: { id: 'vault-test-id' },
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(401);
+	});
+
+	it('should deactivate vault', async () => {
+		const request = new Request('http://localhost/api/vaults/vault-test-id', {
+			method: 'DELETE',
+			headers: { 'X-API-Key': 'secret' }
+		});
+
+		const response = await DELETE({
+			request,
+			params: { id: 'vault-test-id' },
+			platform: { env: { DB: createMockDb(), API_KEY: 'secret' } }
+		} as any);
+
+		expect(response.status).toBe(204);
+	});
+});

--- a/apps/registry/src/routes/api/vaults/[id]/+server.ts
+++ b/apps/registry/src/routes/api/vaults/[id]/+server.ts
@@ -1,0 +1,109 @@
+// Individual vault operations
+/// <reference types="@cloudflare/workers-types" />
+import { json } from '@sveltejs/kit';
+
+interface CloudflarePlatform {
+	env: { DB: D1Database; API_KEY: string };
+}
+
+function checkAuth(request: Request, apiKey: string): boolean {
+	const providedKey = request.headers.get('X-API-Key');
+	return providedKey === apiKey;
+}
+
+export const GET = async ({
+	request,
+	params,
+	platform
+}: {
+	request: Request;
+	params: { id: string };
+	platform?: CloudflarePlatform;
+}) => {
+	if (!platform) throw new Error('Platform not available');
+
+	// Check API key
+	if (!checkAuth(request, platform.env.API_KEY)) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	// Fetch vault
+	const vault = await platform.env.DB.prepare(
+		'SELECT id, name, callback_url, active, created_at FROM vaults WHERE id = ?'
+	)
+		.bind(params.id)
+		.first();
+
+	if (!vault) {
+		return json({ error: 'Vault not found' }, { status: 404 });
+	}
+
+	return json(vault);
+};
+
+export const PUT = async ({
+	request,
+	params,
+	platform
+}: {
+	request: Request;
+	params: { id: string };
+	platform?: CloudflarePlatform;
+}) => {
+	if (!platform) throw new Error('Platform not available');
+
+	// Check API key
+	if (!checkAuth(request, platform.env.API_KEY)) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	// Parse request body
+	const body = (await request.json()) as { callback_url?: string };
+
+	if (!body.callback_url) {
+		return json({ error: 'Missing callback_url' }, { status: 400 });
+	}
+
+	// Validate HTTPS
+	if (!body.callback_url.startsWith('https://')) {
+		return json({ error: 'Callback URL must use HTTPS' }, { status: 400 });
+	}
+
+	// Update vault
+	await platform.env.DB.prepare('UPDATE vaults SET callback_url = ? WHERE id = ?')
+		.bind(body.callback_url, params.id)
+		.run();
+
+	// Return updated vault
+	const vault = await platform.env.DB.prepare(
+		'SELECT id, name, callback_url, active, created_at FROM vaults WHERE id = ?'
+	)
+		.bind(params.id)
+		.first();
+
+	return json(vault);
+};
+
+export const DELETE = async ({
+	request,
+	params,
+	platform
+}: {
+	request: Request;
+	params: { id: string };
+	platform?: CloudflarePlatform;
+}) => {
+	if (!platform) throw new Error('Platform not available');
+
+	// Check API key
+	if (!checkAuth(request, platform.env.API_KEY)) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	// Deactivate vault (soft delete)
+	await platform.env.DB.prepare('UPDATE vaults SET active = 0 WHERE id = ?')
+		.bind(params.id)
+		.run();
+
+	return new Response(null, { status: 204 });
+};


### PR DESCRIPTION
Implements #17

## Changes

- ✅ Created `POST /api/vaults` endpoint to register new vaults
- ✅ Created `GET /api/vaults` endpoint to list all vaults
- ✅ Created `GET /api/vaults/[id]` endpoint to get vault details
- ✅ Created `PUT /api/vaults/[id]` endpoint to update callback URL
- ✅ Created `DELETE /api/vaults/[id]` endpoint to deactivate vault
- ✅ Validate HTTPS requirement for callback URLs
- ✅ Validate vault name uniqueness
- ✅ API key authentication for all endpoints
- ✅ Generate unique vault IDs with nanoid
- ✅ Comprehensive test suite (17 new tests)

## API Endpoints

### Register Vault
```
POST /api/vaults
X-API-Key: secret
{
  "name": "Helsinki Chamber Choir",
  "callback_url": "https://helsinki-choir.polyphony.app/auth/callback"
}
→ 201 Created
{
  "id": "vault-xyz",
  "name": "Helsinki Chamber Choir",
  "callback_url": "https://helsinki-choir.polyphony.app/auth/callback",
  "active": true
}
```

### List Vaults
```
GET /api/vaults
X-API-Key: secret
→ 200 OK
{
  "vaults": [...]
}
```

### Get Vault
```
GET /api/vaults/vault-xyz
X-API-Key: secret
→ 200 OK
```

### Update Callback URL
```
PUT /api/vaults/vault-xyz
X-API-Key: secret
{
  "callback_url": "https://new-url.example.com/callback"
}
→ 200 OK
```

### Deactivate Vault
```
DELETE /api/vaults/vault-xyz
X-API-Key: secret
→ 204 No Content
```

## Test Results

All 41 tests passing:
- 9 vault registration tests (auth, validation, duplicate checks)
- 8 vault operations tests (GET, PUT, DELETE)
- 9 shared package tests (JWT + JWKS)
- 9 auth flow tests (OAuth)
- 4 JWKS endpoint tests
- 2 setup tests

## Security

- All endpoints require `X-API-Key` header
- Callback URLs must use HTTPS
- Vault names must be unique
- Soft delete (deactivation) preserves audit trail

## TDD Workflow

✅ Red: Wrote failing tests first
✅ Green: Implemented all endpoints to pass tests
✅ Refactor: Clean code with proper validation
✅ Verified: All tests passing before commit

Closes #17