### PR TITLE
feat(vault): Implement Score CRUD API endpoints

### DIFF
--- a/apps/vault/src/lib/server/api/scores.ts
+++ b/apps/vault/src/lib/server/api/scores.ts
@@ -1,0 +1,194 @@
+// Score API handlers
+import { createScore, getScoreById, listScores, softDeleteScore, type CreateScoreInput } from '$lib/server/db/scores';
+import { uploadScore, getScoreFile, MAX_FILE_SIZE } from '$lib/server/storage/d1-storage';
+
+export interface ScoreListItem {
+	id: string;
+	title: string;
+	composer: string | null;
+	arranger: string | null;
+	license_type: string;
+	uploaded_at: string;
+}
+
+export interface GetParams {
+	db: D1Database;
+	limit?: number;
+	offset?: number;
+}
+
+export interface GetResult {
+	scores: ScoreListItem[];
+	total: number;
+}
+
+export interface PostParams {
+	db: D1Database;
+	body: {
+		title: string;
+		composer?: string;
+		arranger?: string;
+		license_type: 'public_domain' | 'licensed' | 'owned' | 'pending';
+	};
+	file: File;
+	memberId: string;
+}
+
+export interface PostResult {
+	id: string;
+	title: string;
+	composer: string | null;
+	arranger: string | null;
+	license_type: string;
+}
+
+export interface DeleteParams {
+	db: D1Database;
+	scoreId: string;
+	memberId: string;
+}
+
+export interface DeleteResult {
+	deleted: boolean;
+}
+
+/**
+ * GET /api/scores - List all scores
+ */
+export async function GET(params: GetParams): Promise<GetResult> {
+	const scores = await listScores(params.db);
+
+	return {
+		scores: scores.map((s) => ({
+			id: s.id,
+			title: s.title,
+			composer: s.composer,
+			arranger: s.arranger,
+			license_type: s.license_type,
+			uploaded_at: s.uploaded_at
+		})),
+		total: scores.length
+	};
+}
+
+/**
+ * POST /api/scores - Create new score with PDF upload
+ */
+export async function POST(params: PostParams): Promise<PostResult> {
+	const { db, body, file, memberId } = params;
+
+	// Validate required fields
+	if (!body.title) {
+		throw new Error('Title is required');
+	}
+
+	// Validate file type
+	if (file.type !== 'application/pdf') {
+		throw new Error('Only PDF files are allowed');
+	}
+
+	// Validate file size
+	if (file.size > MAX_FILE_SIZE) {
+		throw new Error('File size exceeds 2MB limit');
+	}
+
+	// Generate ID
+	const id = crypto.randomUUID().replace(/-/g, '').slice(0, 21);
+
+	// Create score metadata in D1
+	const scoreInput: CreateScoreInput = {
+		title: body.title,
+		composer: body.composer,
+		arranger: body.arranger,
+		license_type: body.license_type,
+		file_key: id, // Use score ID as file key
+		uploaded_by: memberId
+	};
+
+	// Insert score record (will use the generated ID from createScore)
+	const score = await createScore(db, scoreInput);
+
+	// Upload file to D1 BLOB storage
+	await uploadScore(db, score.id, file);
+
+	return {
+		id: score.id,
+		title: score.title,
+		composer: score.composer,
+		arranger: score.arranger,
+		license_type: score.license_type
+	};
+}
+
+export interface GetOneParams {
+	db: D1Database;
+	scoreId: string;
+}
+
+/**
+ * GET /api/scores/:id - Get score metadata
+ */
+export async function GET_ONE(params: GetOneParams) {
+	const { db, scoreId } = params;
+
+	const score = await getScoreById(db, scoreId);
+	if (!score) {
+		return null;
+	}
+
+	return {
+		id: score.id,
+		title: score.title,
+		composer: score.composer,
+		arranger: score.arranger,
+		license_type: score.license_type,
+		uploaded_at: score.uploaded_at
+	};
+}
+
+export interface DownloadParams {
+	db: D1Database;
+	scoreId: string;
+}
+
+export interface DownloadResult {
+	data: ArrayBuffer;
+	originalName: string;
+	size: number;
+}
+
+/**
+ * GET /api/scores/:id/download - Download score PDF
+ */
+export async function DOWNLOAD(params: DownloadParams): Promise<DownloadResult | null> {
+	const { db, scoreId } = params;
+
+	// Check score exists and not deleted
+	const score = await getScoreById(db, scoreId);
+	if (!score || score.deleted_at) {
+		return null;
+	}
+
+	// Get file from D1
+	const file = await getScoreFile(db, scoreId);
+	if (!file) {
+		return null;
+	}
+
+	return {
+		data: file.data,
+		originalName: file.originalName,
+		size: file.size
+	};
+}
+
+/**
+ * DELETE /api/scores/:id - Soft delete a score
+ */
+export async function DELETE(params: DeleteParams): Promise<DeleteResult> {
+	const { db, scoreId } = params;
+
+	const deleted = await softDeleteScore(db, scoreId);
+
+	return { deleted };
+}

--- a/apps/vault/src/routes/api/scores/+server.ts
+++ b/apps/vault/src/routes/api/scores/+server.ts
@@ -1,0 +1,61 @@
+// GET /api/scores - List scores
+// POST /api/scores - Upload new score
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { GET as getScores, POST as createScore } from '$lib/server/api/scores';
+
+export const GET: RequestHandler = async ({ platform }) => {
+	if (!platform?.env?.DB) {
+		throw error(500, 'Database not available');
+	}
+
+	const result = await getScores({ db: platform.env.DB });
+	return json(result);
+};
+
+export const POST: RequestHandler = async ({ request, platform }) => {
+	if (!platform?.env?.DB) {
+		throw error(500, 'Database not available');
+	}
+
+	// TODO: Get member ID from auth token
+	const memberId = 'anonymous'; // Placeholder until auth is implemented
+
+	const formData = await request.formData();
+	const file = formData.get('file') as File | null;
+	const title = formData.get('title') as string | null;
+	const composer = formData.get('composer') as string | null;
+	const arranger = formData.get('arranger') as string | null;
+	const license_type = formData.get('license_type') as string | null;
+
+	if (!file) {
+		throw error(400, 'File is required');
+	}
+
+	if (!title) {
+		throw error(400, 'Title is required');
+	}
+
+	if (!license_type || !['public_domain', 'licensed', 'owned', 'pending'].includes(license_type)) {
+		throw error(400, 'Valid license_type is required');
+	}
+
+	try {
+		const result = await createScore({
+			db: platform.env.DB,
+			body: {
+				title,
+				composer: composer ?? undefined,
+				arranger: arranger ?? undefined,
+				license_type: license_type as 'public_domain' | 'licensed' | 'owned' | 'pending'
+			},
+			file,
+			memberId
+		});
+
+		return json(result, { status: 201 });
+	} catch (err) {
+		const message = err instanceof Error ? err.message : 'Upload failed';
+		throw error(400, message);
+	}
+};

--- a/apps/vault/src/routes/api/scores/[id]/+server.ts
+++ b/apps/vault/src/routes/api/scores/[id]/+server.ts
@@ -1,0 +1,40 @@
+// GET /api/scores/:id - Get score metadata
+// DELETE /api/scores/:id - Soft delete score
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { GET_ONE, DELETE as deleteScore } from '$lib/server/api/scores';
+
+export const GET: RequestHandler = async ({ params, platform }) => {
+	if (!platform?.env?.DB) {
+		throw error(500, 'Database not available');
+	}
+
+	const result = await GET_ONE({ db: platform.env.DB, scoreId: params.id });
+
+	if (!result) {
+		throw error(404, 'Score not found');
+	}
+
+	return json(result);
+};
+
+export const DELETE: RequestHandler = async ({ params, platform }) => {
+	if (!platform?.env?.DB) {
+		throw error(500, 'Database not available');
+	}
+
+	// TODO: Check if user has admin/librarian role
+	const memberId = 'anonymous';
+
+	const result = await deleteScore({
+		db: platform.env.DB,
+		scoreId: params.id,
+		memberId
+	});
+
+	if (!result.deleted) {
+		throw error(404, 'Score not found');
+	}
+
+	return json({ deleted: true });
+};

--- a/apps/vault/src/routes/api/scores/[id]/download/+server.ts
+++ b/apps/vault/src/routes/api/scores/[id]/download/+server.ts
@@ -1,0 +1,24 @@
+// GET /api/scores/:id/download - Download score PDF
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { DOWNLOAD } from '$lib/server/api/scores';
+
+export const GET: RequestHandler = async ({ params, platform }) => {
+	if (!platform?.env?.DB) {
+		throw error(500, 'Database not available');
+	}
+
+	const result = await DOWNLOAD({ db: platform.env.DB, scoreId: params.id });
+
+	if (!result) {
+		throw error(404, 'Score not found');
+	}
+
+	return new Response(result.data, {
+		headers: {
+			'Content-Type': 'application/pdf',
+			'Content-Disposition': `attachment; filename="${result.originalName}"`,
+			'Content-Length': result.size.toString()
+		}
+	});
+};

--- a/apps/vault/src/tests/routes/api/scores/scores.spec.ts
+++ b/apps/vault/src/tests/routes/api/scores/scores.spec.ts
@@ -1,0 +1,209 @@
+// Score API endpoint tests
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GET, POST, DELETE } from '$lib/server/api/scores';
+
+// Mock D1 database
+function createMockD1() {
+	const members = new Map<string, { id: string; email: string; name: string; role: string }>();
+	const scores = new Map<string, { id: string; title: string; composer: string | null; arranger: string | null; license_type: string; file_key: string; uploaded_by: string | null; uploaded_at: string; deleted_at: string | null }>();
+	const scoreFiles = new Map<string, { score_id: string; data: ArrayBuffer; size: number; original_name: string; uploaded_at: string }>();
+
+	// Seed test member
+	members.set('member_1', { id: 'member_1', email: 'test@choir.org', name: 'Test User', role: 'librarian' });
+
+	return {
+		prepare: (sql: string) => ({
+			bind: (...params: unknown[]) => ({
+				run: async () => {
+					if (sql.includes('INSERT INTO scores')) {
+						const [id, title, composer, arranger, license_type, file_key, uploaded_by] = params as string[];
+						scores.set(id, { id, title, composer, arranger, license_type, file_key, uploaded_by, uploaded_at: new Date().toISOString(), deleted_at: null });
+						return { meta: { changes: 1 } };
+					}
+					if (sql.includes('INSERT INTO score_files')) {
+						const [score_id, data, size, original_name] = params as [string, ArrayBuffer, number, string];
+						scoreFiles.set(score_id, { score_id, data, size, original_name, uploaded_at: new Date().toISOString() });
+						return { meta: { changes: 1 } };
+					}
+					if (sql.includes('UPDATE scores SET deleted_at')) {
+						const [id] = params as [string];
+						const score = scores.get(id);
+						if (score && !score.deleted_at) {
+							score.deleted_at = new Date().toISOString();
+							return { meta: { changes: 1 } };
+						}
+						return { meta: { changes: 0 } };
+					}
+					return { meta: { changes: 0 } };
+				},
+				first: async <T>() => {
+					if (sql.includes('SELECT') && sql.includes('FROM scores WHERE id')) {
+						const [id] = params as [string];
+						return (scores.get(id) ?? null) as T;
+					}
+					if (sql.includes('SELECT') && sql.includes('FROM score_files')) {
+						const [score_id] = params as [string];
+						return (scoreFiles.get(score_id) ?? null) as T;
+					}
+					if (sql.includes('SELECT') && sql.includes('FROM members')) {
+						const [id] = params as [string];
+						return (members.get(id) ?? null) as T;
+					}
+					return null;
+				},
+				all: async <T>() => {
+					if (sql.includes('SELECT') && sql.includes('FROM scores') && sql.includes('deleted_at IS NULL')) {
+						const results = Array.from(scores.values()).filter(s => !s.deleted_at);
+						return { results: results as T[] };
+					}
+					return { results: [] };
+				}
+			}),
+			// Direct .all() without bind (used by listScores)
+			all: async <T>() => {
+				if (sql.includes('SELECT') && sql.includes('FROM scores') && sql.includes('deleted_at IS NULL')) {
+					const results = Array.from(scores.values()).filter(s => !s.deleted_at);
+					return { results: results as T[] };
+				}
+				return { results: [] };
+			}
+		}),
+		batch: async () => [],
+		dump: async () => new ArrayBuffer(0),
+		exec: async () => ({ count: 0, duration: 0 })
+	} as unknown as D1Database;
+}
+
+describe('Score API', () => {
+	let db: D1Database;
+
+	beforeEach(() => {
+		db = createMockD1();
+	});
+
+	describe('GET /api/scores', () => {
+		it('returns empty list when no scores', async () => {
+			const result = await GET({ db });
+
+			expect(result.scores).toEqual([]);
+			expect(result.total).toBe(0);
+		});
+
+		it('returns list of scores', async () => {
+			// Create a score first
+			const pdfContent = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+			const file = new File([pdfContent], 'test.pdf', { type: 'application/pdf' });
+
+			await POST({
+				db,
+				body: {
+					title: 'Test Song',
+					composer: 'J.S. Bach',
+					license_type: 'public_domain'
+				},
+				file,
+				memberId: 'member_1'
+			});
+
+			const result = await GET({ db });
+
+			expect(result.scores).toHaveLength(1);
+			expect(result.scores[0].title).toBe('Test Song');
+			expect(result.scores[0].composer).toBe('J.S. Bach');
+			expect(result.total).toBe(1);
+		});
+	});
+
+	describe('POST /api/scores', () => {
+		it('creates a new score with PDF', async () => {
+			const pdfContent = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+			const file = new File([pdfContent], 'song.pdf', { type: 'application/pdf' });
+
+			const result = await POST({
+				db,
+				body: {
+					title: 'Amazing Grace',
+					composer: 'John Newton',
+					arranger: 'arr. Smith',
+					license_type: 'public_domain'
+				},
+				file,
+				memberId: 'member_1'
+			});
+
+			expect(result.id).toBeDefined();
+			expect(result.title).toBe('Amazing Grace');
+			expect(result.composer).toBe('John Newton');
+		});
+
+		it('rejects non-PDF files', async () => {
+			const textContent = new TextEncoder().encode('not a pdf');
+			const file = new File([textContent], 'test.txt', { type: 'text/plain' });
+
+			await expect(
+				POST({
+					db,
+					body: { title: 'Test', license_type: 'public_domain' },
+					file,
+					memberId: 'member_1'
+				})
+			).rejects.toThrow('Only PDF files are allowed');
+		});
+
+		it('rejects files over 2MB', async () => {
+			const largeContent = new Uint8Array(2 * 1024 * 1024 + 1);
+			const file = new File([largeContent], 'large.pdf', { type: 'application/pdf' });
+
+			await expect(
+				POST({
+					db,
+					body: { title: 'Test', license_type: 'public_domain' },
+					file,
+					memberId: 'member_1'
+				})
+			).rejects.toThrow('File size exceeds 2MB limit');
+		});
+
+		it('requires title', async () => {
+			const pdfContent = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+			const file = new File([pdfContent], 'test.pdf', { type: 'application/pdf' });
+
+			await expect(
+				POST({
+					db,
+					body: { license_type: 'public_domain' } as any,
+					file,
+					memberId: 'member_1'
+				})
+			).rejects.toThrow('Title is required');
+		});
+	});
+
+	describe('DELETE /api/scores/:id', () => {
+		it('soft deletes an existing score', async () => {
+			// Create first
+			const pdfContent = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+			const file = new File([pdfContent], 'test.pdf', { type: 'application/pdf' });
+			const created = await POST({
+				db,
+				body: { title: 'To Delete', license_type: 'public_domain' },
+				file,
+				memberId: 'member_1'
+			});
+
+			const result = await DELETE({ db, scoreId: created.id, memberId: 'member_1' });
+
+			expect(result.deleted).toBe(true);
+
+			// Should not appear in list
+			const list = await GET({ db });
+			expect(list.scores).toHaveLength(0);
+		});
+
+		it('returns false for non-existent score', async () => {
+			const result = await DELETE({ db, scoreId: 'nonexistent', memberId: 'member_1' });
+
+			expect(result.deleted).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implements REST API for score management - the core CRUD functionality of the Vault.

Closes #5

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | /api/scores | List all non-deleted scores |
| POST | /api/scores | Upload new score (multipart form) |
| GET | /api/scores/:id | Get score metadata |
| GET | /api/scores/:id/download | Download PDF file |
| DELETE | /api/scores/:id | Soft delete score |

## Implementation

- `src/lib/server/api/scores.ts` - API handler functions
- `src/routes/api/scores/` - SvelteKit route handlers
- Input validation (title required, PDF only, ≤2MB)
- Uses D1 BLOB storage from #33

## Testing

```bash
cd apps/vault && pnpm test
# 24 tests passing (8 new)
```

## TODO (future issues)

- [ ] Auth integration (currently uses placeholder memberId)
- [ ] Permission checks for DELETE (admin/librarian only)
- [ ] Pagination for list endpoint