### PR TITLE
feat(vault): add score library and upload UI pages

### DIFF
--- a/apps/vault/src/routes/+page.svelte
+++ b/apps/vault/src/routes/+page.svelte
@@ -17,6 +17,21 @@
 
 		{#if mounted}
 			<div class="bg-white rounded-lg shadow-md p-8">
+				<div class="flex gap-4 justify-center mb-8">
+					<a
+						href="/library"
+						class="rounded-lg bg-blue-600 px-6 py-3 text-white font-medium hover:bg-blue-700 transition"
+					>
+						Browse Library
+					</a>
+					<a
+						href="/upload"
+						class="rounded-lg bg-gray-100 px-6 py-3 text-gray-700 font-medium hover:bg-gray-200 transition"
+					>
+						Upload Score
+					</a>
+				</div>
+
 				<h2 class="text-2xl font-semibold text-gray-800 mb-4">Phase 1: MVP</h2>
 				<p class="text-gray-600 mb-6">
 					A standalone vault application for managing choir sheet music libraries.
@@ -39,12 +54,6 @@
 						<h3 class="font-semibold text-gray-800">Copyright Protection</h3>
 						<p class="text-sm text-gray-600">Handle takedown requests transparently</p>
 					</div>
-				</div>
-
-				<div class="mt-8 pt-6 border-t border-gray-200">
-					<p class="text-sm text-gray-500">
-						Coming soon: Authentication, score upload, member management
-					</p>
 				</div>
 			</div>
 		{/if}

--- a/apps/vault/src/routes/library/+page.server.ts
+++ b/apps/vault/src/routes/library/+page.server.ts
@@ -1,0 +1,23 @@
+import type { PageServerLoad } from './$types';
+
+interface Score {
+	id: string;
+	title: string;
+	composer: string | null;
+	arranger: string | null;
+	license_type: string;
+	uploaded_at: string;
+}
+
+interface ScoresResponse {
+	scores: Score[];
+}
+
+export const load: PageServerLoad = async ({ fetch }) => {
+	const response = await fetch('/api/scores');
+	const data = (await response.json()) as ScoresResponse;
+
+	return {
+		scores: data.scores ?? []
+	};
+};

--- a/apps/vault/src/routes/library/+page.svelte
+++ b/apps/vault/src/routes/library/+page.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	interface Score {
+		id: string;
+		title: string;
+		composer: string | null;
+		arranger: string | null;
+		license_type: string;
+		uploaded_at: string;
+	}
+
+	let { data }: { data: PageData } = $props();
+
+	let searchQuery = $state('');
+
+	let filteredScores = $derived(
+		data.scores.filter(
+			(s: Score) =>
+				s.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+				(s.composer?.toLowerCase().includes(searchQuery.toLowerCase()) ?? false)
+		)
+	);
+</script>
+
+<svelte:head>
+	<title>Library | Polyphony Vault</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl px-4 py-8">
+	<div class="mb-8 flex items-center justify-between">
+		<h1 class="text-3xl font-bold">Score Library</h1>
+		<a
+			href="/upload"
+			class="rounded-lg bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700"
+		>
+			Upload Score
+		</a>
+	</div>
+
+	<!-- Search -->
+	<div class="mb-6">
+		<input
+			type="text"
+			bind:value={searchQuery}
+			placeholder="Search by title or composer..."
+			class="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+		/>
+	</div>
+
+	<!-- Score List -->
+	{#if filteredScores.length === 0}
+		<div class="py-12 text-center text-gray-500">
+			{#if data.scores.length === 0}
+				<p class="text-lg">No scores yet.</p>
+				<p class="mt-2">
+					<a href="/upload" class="text-blue-600 hover:underline">Upload your first score</a>
+				</p>
+			{:else}
+				<p>No scores match your search.</p>
+			{/if}
+		</div>
+	{:else}
+		<div class="space-y-4">
+			{#each filteredScores as score}
+				<div
+					class="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+				>
+					<div>
+						<h2 class="text-lg font-semibold">{score.title}</h2>
+						{#if score.composer}
+							<p class="text-gray-600">{score.composer}</p>
+						{/if}
+						{#if score.arranger}
+							<p class="text-sm text-gray-500">arr. {score.arranger}</p>
+						{/if}
+						<p class="mt-1 text-xs text-gray-400">
+							{new Date(score.uploaded_at).toLocaleDateString()}
+						</p>
+					</div>
+					<a
+						href="/api/scores/{score.id}/download"
+						class="rounded-lg bg-gray-100 px-4 py-2 text-gray-700 transition hover:bg-gray-200"
+					>
+						Download
+					</a>
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	<p class="mt-6 text-sm text-gray-500">
+		{filteredScores.length} of {data.scores.length} scores
+	</p>
+</div>

--- a/apps/vault/src/routes/upload/+page.svelte
+++ b/apps/vault/src/routes/upload/+page.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+
+	let title = $state('');
+	let composer = $state('');
+	let arranger = $state('');
+	let licenseType = $state<'public_domain' | 'licensed' | 'owned' | 'pending'>('pending');
+	let file = $state<File | null>(null);
+
+	let isUploading = $state(false);
+	let uploadProgress = $state(0);
+	let error = $state('');
+
+	const MAX_SIZE = 2 * 1024 * 1024; // 2MB
+
+	function handleFileChange(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const selectedFile = input.files?.[0];
+
+		if (!selectedFile) {
+			file = null;
+			return;
+		}
+
+		// Client-side validation
+		if (selectedFile.type !== 'application/pdf') {
+			error = 'Only PDF files are allowed';
+			file = null;
+			input.value = '';
+			return;
+		}
+
+		if (selectedFile.size > MAX_SIZE) {
+			error = 'File size must be under 2MB';
+			file = null;
+			input.value = '';
+			return;
+		}
+
+		error = '';
+		file = selectedFile;
+	}
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+
+		if (!file || !title) {
+			error = 'Title and file are required';
+			return;
+		}
+
+		isUploading = true;
+		uploadProgress = 0;
+		error = '';
+
+		try {
+			const formData = new FormData();
+			formData.append('title', title);
+			formData.append('license_type', licenseType);
+			formData.append('file', file);
+
+			if (composer) formData.append('composer', composer);
+			if (arranger) formData.append('arranger', arranger);
+
+			// Simulate progress for better UX
+			const progressInterval = setInterval(() => {
+				if (uploadProgress < 90) {
+					uploadProgress += 10;
+				}
+			}, 100);
+
+			const response = await fetch('/api/scores', {
+				method: 'POST',
+				body: formData
+			});
+
+			clearInterval(progressInterval);
+
+			if (!response.ok) {
+				const data = (await response.json()) as { message?: string };
+				throw new Error(data.message ?? 'Upload failed');
+			}
+
+			uploadProgress = 100;
+
+			// Redirect to library after successful upload
+			setTimeout(() => {
+				goto('/library');
+			}, 500);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Upload failed';
+			isUploading = false;
+			uploadProgress = 0;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Upload Score | Polyphony Vault</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-xl px-4 py-8">
+	<div class="mb-8">
+		<a href="/library" class="text-blue-600 hover:underline">← Back to Library</a>
+	</div>
+
+	<h1 class="mb-6 text-3xl font-bold">Upload Score</h1>
+
+	<form onsubmit={handleSubmit} class="space-y-6">
+		<!-- Title -->
+		<div>
+			<label for="title" class="mb-1 block font-medium">
+				Title <span class="text-red-500">*</span>
+			</label>
+			<input
+				id="title"
+				type="text"
+				bind:value={title}
+				required
+				class="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+				placeholder="e.g., Ave Maria"
+			/>
+		</div>
+
+		<!-- Composer -->
+		<div>
+			<label for="composer" class="mb-1 block font-medium">Composer</label>
+			<input
+				id="composer"
+				type="text"
+				bind:value={composer}
+				class="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+				placeholder="e.g., Franz Schubert"
+			/>
+		</div>
+
+		<!-- Arranger -->
+		<div>
+			<label for="arranger" class="mb-1 block font-medium">Arranger</label>
+			<input
+				id="arranger"
+				type="text"
+				bind:value={arranger}
+				class="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+				placeholder="e.g., arr. John Smith"
+			/>
+		</div>
+
+		<!-- License Type -->
+		<div>
+			<label for="license" class="mb-1 block font-medium">
+				License Status <span class="text-red-500">*</span>
+			</label>
+			<select
+				id="license"
+				bind:value={licenseType}
+				class="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+			>
+				<option value="public_domain">Public Domain</option>
+				<option value="licensed">Licensed (purchased)</option>
+				<option value="owned">Owned (original work)</option>
+				<option value="pending">Pending Verification</option>
+			</select>
+		</div>
+
+		<!-- File Upload -->
+		<div>
+			<label for="file" class="mb-1 block font-medium">
+				PDF File <span class="text-red-500">*</span>
+			</label>
+			<input
+				id="file"
+				type="file"
+				accept=".pdf,application/pdf"
+				onchange={handleFileChange}
+				class="w-full rounded-lg border border-gray-300 px-4 py-2 file:mr-4 file:rounded file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-blue-700 hover:file:bg-blue-100"
+			/>
+			<p class="mt-1 text-sm text-gray-500">PDF only, max 2MB</p>
+			{#if file}
+				<p class="mt-1 text-sm text-green-600">
+					Selected: {file.name} ({(file.size / 1024).toFixed(1)} KB)
+				</p>
+			{/if}
+		</div>
+
+		<!-- Error Message -->
+		{#if error}
+			<div class="rounded-lg bg-red-50 p-4 text-red-600">
+				{error}
+			</div>
+		{/if}
+
+		<!-- Progress Bar -->
+		{#if isUploading}
+			<div class="relative h-2 overflow-hidden rounded-full bg-gray-200">
+				<div
+					class="absolute left-0 top-0 h-full bg-blue-600 transition-all duration-200"
+					style="width: {uploadProgress}%"
+				></div>
+			</div>
+			<p class="text-center text-sm text-gray-600">Uploading... {uploadProgress}%</p>
+		{/if}
+
+		<!-- Submit Button -->
+		<button
+			type="submit"
+			disabled={isUploading || !title || !file}
+			class="w-full rounded-lg bg-blue-600 px-4 py-3 font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+		>
+			{isUploading ? 'Uploading...' : 'Upload Score'}
+		</button>
+	</form>
+</div>


### PR DESCRIPTION
## Summary
Implements the score library browsing and upload UI for Issue #6.

## Changes
- **Homepage**: Added navigation buttons to Browse Library and Upload Score
- **Library page** (`/library`): Browse all scores with search by title/composer, download buttons
- **Upload page** (`/upload`): Form with title, composer, arranger, license type, file input
- **Client-side validation**: PDF type check, 2MB size limit, required fields

## Technical Details
- Uses Svelte 5 runes (`$state`, `$derived`, `$props`)
- TypeScript strict mode compatible
- Tailwind CSS styling

## Testing
- All 24 existing tests pass
- Type check passes (0 errors)

Closes #6