### PR TITLE
feat(vault): OAuth login flow via registry

### DIFF
--- a/apps/vault/src/routes/+layout.server.ts
+++ b/apps/vault/src/routes/+layout.server.ts
@@ -1,0 +1,35 @@
+// Server load for root layout - provides auth state to all pages
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ platform, cookies }) => {
+	const memberId = cookies.get('member_id');
+
+	if (!memberId || !platform?.env?.DB) {
+		return { user: null };
+	}
+
+	try {
+		const member = await platform.env.DB.prepare(
+			'SELECT id, email, name, role FROM members WHERE id = ?'
+		)
+			.bind(memberId)
+			.first<{ id: string; email: string; name: string | null; role: string }>();
+
+		if (!member) {
+			// Invalid session - clear cookie
+			cookies.delete('member_id', { path: '/' });
+			return { user: null };
+		}
+
+		return {
+			user: {
+				id: member.id,
+				email: member.email,
+				name: member.name,
+				role: member.role
+			}
+		};
+	} catch {
+		return { user: null };
+	}
+};

--- a/apps/vault/src/routes/+layout.svelte
+++ b/apps/vault/src/routes/+layout.svelte
@@ -1,7 +1,41 @@
 <script lang="ts">
 	import '../app.css';
+	import type { LayoutData } from './$types';
 
-	let { children } = $props();
+	let { data, children }: { data: LayoutData; children: import('svelte').Snippet } = $props();
 </script>
 
-{@render children()}
+<div class="min-h-screen bg-gray-50">
+	<!-- Header -->
+	<header class="border-b bg-white shadow-sm">
+		<nav class="container mx-auto flex items-center justify-between px-4 py-3">
+			<a href="/" class="text-xl font-bold text-gray-900">Polyphony Vault</a>
+
+			<div class="flex items-center gap-4">
+				<a href="/library" class="text-gray-600 hover:text-gray-900">Library</a>
+				{#if data.user}
+					<a href="/upload" class="text-gray-600 hover:text-gray-900">Upload</a>
+					<span class="text-sm text-gray-500">{data.user.name ?? data.user.email}</span>
+					<a
+						href="/api/auth/logout"
+						class="rounded-lg bg-gray-200 px-3 py-1 text-sm text-gray-700 hover:bg-gray-300"
+					>
+						Logout
+					</a>
+				{:else}
+					<a
+						href="/api/auth/login"
+						class="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+					>
+						Sign In
+					</a>
+				{/if}
+			</div>
+		</nav>
+	</header>
+
+	<!-- Main Content -->
+	<main>
+		{@render children()}
+	</main>
+</div>

--- a/apps/vault/src/routes/api/auth/callback/+server.ts
+++ b/apps/vault/src/routes/api/auth/callback/+server.ts
@@ -1,0 +1,135 @@
+// GET /api/auth/callback?token=xxx - Receive JWT from registry after OAuth
+import { redirect, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { verifyToken } from '@polyphony/shared/crypto';
+import { nanoid } from 'nanoid';
+
+// Registry URL for fetching JWKS
+const REGISTRY_URL = 'https://polyphony-registry.pages.dev';
+
+// Cache JWKS for 5 minutes
+let jwksCache: { keys: Array<{ kid: string; x: string; crv: string; kty: string }> } | null = null;
+let jwksCacheExpiry = 0;
+
+async function fetchJWKS(fetchFn: typeof fetch): Promise<typeof jwksCache> {
+	const now = Date.now();
+	if (jwksCache && now < jwksCacheExpiry) {
+		return jwksCache;
+	}
+
+	const response = await fetchFn(`${REGISTRY_URL}/.well-known/jwks.json`);
+	if (!response.ok) {
+		throw new Error('Failed to fetch JWKS from registry');
+	}
+
+	jwksCache = await response.json();
+	jwksCacheExpiry = now + 5 * 60 * 1000; // 5 minutes
+	return jwksCache;
+}
+
+// Convert JWK to PEM format for jose library
+async function jwkToPem(jwk: { x: string; crv: string; kty: string }): Promise<string> {
+	// For Ed25519, we need to construct SPKI format
+	// The 'x' value is the raw public key in base64url
+	const x = jwk.x.replace(/-/g, '+').replace(/_/g, '/');
+	const padding = '='.repeat((4 - (x.length % 4)) % 4);
+	const base64 = x + padding;
+
+	// Ed25519 public key SPKI prefix (ASN.1 header for Ed25519)
+	const prefix = new Uint8Array([
+		0x30, 0x2a, // SEQUENCE, 42 bytes
+		0x30, 0x05, // SEQUENCE, 5 bytes
+		0x06, 0x03, 0x2b, 0x65, 0x70, // OID 1.3.101.112 (Ed25519)
+		0x03, 0x21, 0x00 // BIT STRING, 33 bytes (with leading 0)
+	]);
+
+	// Decode base64 to get raw key bytes
+	const rawKey = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+
+	// Combine prefix and raw key
+	const spki = new Uint8Array(prefix.length + rawKey.length);
+	spki.set(prefix);
+	spki.set(rawKey, prefix.length);
+
+	// Convert to base64 and format as PEM
+	const spkiBase64 = btoa(String.fromCharCode(...spki));
+	const lines = spkiBase64.match(/.{1,64}/g) || [];
+	return `-----BEGIN PUBLIC KEY-----\n${lines.join('\n')}\n-----END PUBLIC KEY-----`;
+}
+
+export const GET: RequestHandler = async ({ url, platform, cookies, fetch: svelteKitFetch }) => {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	const token = url.searchParams.get('token');
+	if (!token) {
+		throw error(400, 'Missing token parameter');
+	}
+
+	try {
+		// Fetch JWKS from registry
+		const jwks = await fetchJWKS(svelteKitFetch);
+		if (!jwks || jwks.keys.length === 0) {
+			throw error(500, 'No signing keys available');
+		}
+
+		// Use the first active key
+		const jwk = jwks.keys[0];
+		const publicKeyPem = await jwkToPem(jwk);
+
+		// Verify the token
+		const payload = await verifyToken(token, publicKeyPem);
+
+		// Check the audience matches our vault ID
+		// TODO: Make vault ID configurable via environment variable
+		const expectedVaultId = 'BQ6u9ENTnZk_danhhIbUB';
+		if (payload.aud !== expectedVaultId) {
+			throw error(403, 'Token not issued for this vault');
+		}
+
+		// Find or create member by email
+		let member = await db
+			.prepare('SELECT id, email, name, role FROM members WHERE email = ?')
+			.bind(payload.email)
+			.first<{ id: string; email: string; name: string | null; role: string }>();
+
+		if (!member) {
+			// Create new member with 'singer' role (default for new OAuth users)
+			const memberId = nanoid(21);
+			await db
+				.prepare(
+					'INSERT INTO members (id, email, name, role, created_at) VALUES (?, ?, ?, ?, ?)'
+				)
+				.bind(memberId, payload.email, payload.name || null, 'singer', new Date().toISOString())
+				.run();
+
+			member = { id: memberId, email: payload.email, name: payload.name || null, role: 'singer' };
+		} else if (payload.name && member.name !== payload.name) {
+			// Update name if changed
+			await db
+				.prepare('UPDATE members SET name = ? WHERE id = ?')
+				.bind(payload.name, member.id)
+				.run();
+		}
+
+		// Create session cookie
+		cookies.set('member_id', member.id, {
+			path: '/',
+			httpOnly: true,
+			secure: true,
+			sameSite: 'lax',
+			maxAge: 60 * 60 * 24 * 7 // 1 week
+		});
+
+		// Redirect to library
+		return redirect(302, '/library');
+	} catch (err) {
+		console.error('Auth callback error:', err);
+		if (err instanceof Error && err.message.includes('expired')) {
+			throw error(401, 'Token expired. Please try logging in again.');
+		}
+		throw error(401, 'Invalid or expired token');
+	}
+};

--- a/apps/vault/src/routes/api/auth/login/+server.ts
+++ b/apps/vault/src/routes/api/auth/login/+server.ts
@@ -1,0 +1,18 @@
+// GET /api/auth/login - Redirect to registry for OAuth
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+const REGISTRY_URL = 'https://polyphony-registry.pages.dev';
+const VAULT_ID = 'BQ6u9ENTnZk_danhhIbUB';
+
+export const GET: RequestHandler = async ({ url }) => {
+	// Build callback URL (same origin as request)
+	const callbackUrl = `${url.origin}/api/auth/callback`;
+
+	// Redirect to registry OAuth
+	const registryAuthUrl = new URL('/auth', REGISTRY_URL);
+	registryAuthUrl.searchParams.set('vault_id', VAULT_ID);
+	registryAuthUrl.searchParams.set('callback', callbackUrl);
+
+	return redirect(302, registryAuthUrl.toString());
+};

--- a/apps/vault/src/routes/api/auth/logout/+server.ts
+++ b/apps/vault/src/routes/api/auth/logout/+server.ts
@@ -1,0 +1,8 @@
+// GET /api/auth/logout - Clear session and redirect to home
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ cookies }) => {
+	cookies.delete('member_id', { path: '/' });
+	return redirect(302, '/');
+};

--- a/apps/vault/src/routes/copyright/+page.svelte
+++ b/apps/vault/src/routes/copyright/+page.svelte
@@ -31,7 +31,7 @@
 			if (response.ok) {
 				submitted = true;
 			} else {
-				const result = await response.json();
+				const result = (await response.json()) as { error?: string };
 				error = result.error || 'Failed to submit takedown request';
 			}
 		} catch (e) {

--- a/apps/vault/src/routes/upload/+page.server.ts
+++ b/apps/vault/src/routes/upload/+page.server.ts
@@ -1,0 +1,14 @@
+// Server load for upload page - check auth before showing form
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ parent }) => {
+	const { user } = await parent();
+
+	// If not logged in, we'll show login prompt in the page
+	// If logged in but wrong role, we'll also show appropriate message
+
+	return {
+		canUpload: user?.role === 'librarian' || user?.role === 'admin'
+	};
+};

--- a/apps/vault/src/routes/upload/+page.svelte
+++ b/apps/vault/src/routes/upload/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
 
 	let title = $state('');
 	let composer = $state('');
@@ -106,7 +109,36 @@
 
 	<h1 class="mb-6 text-3xl font-bold">Upload Score</h1>
 
-	<form onsubmit={handleSubmit} class="space-y-6">
+	{#if !data.canUpload}
+		<!-- Not authorized to upload -->
+		<div class="rounded-lg border border-gray-200 bg-white p-8 text-center shadow-sm">
+			<svg
+				class="mx-auto mb-4 h-16 w-16 text-gray-400"
+				fill="none"
+				stroke="currentColor"
+				viewBox="0 0 24 24"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+				/>
+			</svg>
+			<h2 class="mb-2 text-xl font-semibold text-gray-900">Authentication Required</h2>
+			<p class="mb-6 text-gray-600">
+				You need to be signed in as a librarian or admin to upload scores.
+			</p>
+			<a
+				href="/api/auth/login"
+				class="inline-block rounded-lg bg-blue-600 px-6 py-3 font-medium text-white transition hover:bg-blue-700"
+			>
+				Sign In with Google
+			</a>
+		</div>
+	{:else}
+		<!-- Upload form -->
+		<form onsubmit={handleSubmit} class="space-y-6">
 		<!-- Title -->
 		<div>
 			<label for="title" class="mb-1 block font-medium">
@@ -210,4 +242,5 @@
 			{isUploading ? 'Uploading...' : 'Upload Score'}
 		</button>
 	</form>
+	{/if}
 </div>

--- a/apps/vault/src/tests/lib/server/db/takedowns.spec.ts
+++ b/apps/vault/src/tests/lib/server/db/takedowns.spec.ts
@@ -34,7 +34,7 @@ function createMockDb() {
 							claimant_name,
 							claimant_email,
 							reason,
-							attestation: attestation === '1' || attestation === true,
+							attestation: attestation === '1' || attestation === 'true',
 							status: 'pending',
 							created_at: new Date().toISOString(),
 							processed_at: null,


### PR DESCRIPTION
Implements OAuth login for vault users via the registry.

## Changes
- Add `/api/auth/callback` endpoint to receive JWT from registry
- Add `/api/auth/login` to redirect to registry OAuth  
- Add `/api/auth/logout` to clear session
- Add layout with header showing login/logout and user info
- Update upload page to show login prompt when not authenticated
- Add `+layout.server.ts` to provide user state to all pages
- Fix type errors in copyright.spec.ts and takedowns.spec.ts

## Testing
- All 104 vault tests pass
- svelte-check reports no errors

Closes #43