### PR TITLE
feat: Add conductor role to permission system

### DIFF
--- a/apps/vault/migrations/0011_add_conductor_role.sql
+++ b/apps/vault/migrations/0011_add_conductor_role.sql
@@ -1,0 +1,26 @@
+-- Migration: 0011_add_conductor_role.sql
+-- Adds 'conductor' role to member_roles CHECK constraint
+-- Related: https://github.com/mitselek/polyphony/issues/55
+
+-- SQLite doesn't support ALTER TABLE ... ALTER COLUMN, so we need to recreate the table
+
+-- 1. Create new member_roles table with updated CHECK constraint
+CREATE TABLE member_roles_new (
+    member_id TEXT NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('owner', 'admin', 'librarian', 'conductor')),
+    granted_at TEXT DEFAULT (datetime('now')),
+    granted_by TEXT,
+    PRIMARY KEY (member_id, role)
+);
+
+-- 2. Copy existing data
+INSERT INTO member_roles_new (member_id, role, granted_at, granted_by)
+SELECT member_id, role, granted_at, granted_by FROM member_roles;
+
+-- 3. Drop old table and rename new one
+DROP TABLE member_roles;
+ALTER TABLE member_roles_new RENAME TO member_roles;
+
+-- 4. Recreate indexes
+CREATE INDEX IF NOT EXISTS idx_member_roles_member ON member_roles(member_id);
+CREATE INDEX IF NOT EXISTS idx_member_roles_role ON member_roles(role);

--- a/apps/vault/src/lib/server/auth/permissions.ts
+++ b/apps/vault/src/lib/server/auth/permissions.ts
@@ -1,6 +1,6 @@
 // Permission system for role-based access control
 
-export type Role = 'owner' | 'admin' | 'librarian';
+export type Role = 'owner' | 'admin' | 'librarian' | 'conductor';
 
 export type Permission =
 	| 'scores:view'
@@ -10,7 +10,11 @@ export type Permission =
 	| 'members:invite'
 	| 'members:manage'
 	| 'roles:manage'
-	| 'vault:delete';
+	| 'vault:delete'
+	| 'events:create'
+	| 'events:manage'
+	| 'events:delete'
+	| 'attendance:record';
 
 export interface Member {
 	id: string;
@@ -30,6 +34,7 @@ export interface RequireRoleResult {
 const PERMISSIONS: Record<Role, Permission[]> = {
 	librarian: ['scores:upload', 'scores:delete'],
 	admin: ['members:invite', 'roles:manage'],
+	conductor: ['events:create', 'events:manage', 'events:delete', 'attendance:record'],
 	owner: ['vault:delete'] // Owner gets all permissions
 };
 
@@ -110,4 +115,20 @@ export function canManageRoles(member: Member | null | undefined): boolean {
 
 export function canDeleteVault(member: Member | null | undefined): boolean {
 	return hasPermission(member, 'vault:delete');
+}
+
+export function canCreateEvents(member: Member | null | undefined): boolean {
+	return hasPermission(member, 'events:create');
+}
+
+export function canManageEvents(member: Member | null | undefined): boolean {
+	return hasPermission(member, 'events:manage');
+}
+
+export function canDeleteEvents(member: Member | null | undefined): boolean {
+	return hasPermission(member, 'events:delete');
+}
+
+export function canRecordAttendance(member: Member | null | undefined): boolean {
+	return hasPermission(member, 'attendance:record');
 }

--- a/apps/vault/src/lib/types.ts
+++ b/apps/vault/src/lib/types.ts
@@ -1,7 +1,7 @@
 // Shared types for the vault application
 // These types are used across both server and client code
 
-export type Role = 'owner' | 'admin' | 'librarian';
+export type Role = 'owner' | 'admin' | 'librarian' | 'conductor';
 export type VoicePart =
 	| 'S'
 	| 'A'

--- a/apps/vault/src/tests/lib/server/auth/permissions.spec.ts
+++ b/apps/vault/src/tests/lib/server/auth/permissions.spec.ts
@@ -110,4 +110,41 @@ describe('Permission System', () => {
 			expect(canManageRoles({ id: '4', roles: [], email: 't@t.com' })).toBe(false);
 		});
 	});
+
+	describe('conductor role permissions', () => {
+		it('conductor has event management permissions', () => {
+			const conductor: Member = { id: '5', email: 'conductor@test.com', roles: ['conductor'] };
+			expect(hasPermission(conductor, 'events:create')).toBe(true);
+			expect(hasPermission(conductor, 'events:manage')).toBe(true);
+			expect(hasPermission(conductor, 'events:delete')).toBe(true);
+			expect(hasPermission(conductor, 'attendance:record')).toBe(true);
+		});
+
+		it('conductor does not have score management permissions', () => {
+			const conductor: Member = { id: '5', email: 'conductor@test.com', roles: ['conductor'] };
+			expect(hasPermission(conductor, 'scores:upload')).toBe(false);
+			expect(hasPermission(conductor, 'scores:delete')).toBe(false);
+		});
+
+		it('conductor does not have member management permissions', () => {
+			const conductor: Member = { id: '5', email: 'conductor@test.com', roles: ['conductor'] };
+			expect(hasPermission(conductor, 'members:invite')).toBe(false);
+			expect(hasPermission(conductor, 'roles:manage')).toBe(false);
+			expect(hasPermission(conductor, 'vault:delete')).toBe(false);
+		});
+
+		it('conductor can view and download scores (implicit)', () => {
+			const conductor: Member = { id: '5', email: 'conductor@test.com', roles: ['conductor'] };
+			expect(hasPermission(conductor, 'scores:view')).toBe(true);
+			expect(hasPermission(conductor, 'scores:download')).toBe(true);
+		});
+
+		it('owner has all conductor permissions', () => {
+			const owner: Member = { id: '1', email: 'owner@test.com', roles: ['owner'] };
+			expect(hasPermission(owner, 'events:create')).toBe(true);
+			expect(hasPermission(owner, 'events:manage')).toBe(true);
+			expect(hasPermission(owner, 'events:delete')).toBe(true);
+			expect(hasPermission(owner, 'attendance:record')).toBe(true);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Implements Issue #55: Add conductor role to permission system.

Part of Epic #53 (Phase 1: Role System Expansion).

## Changes

**Type System:**
- Updated `Role` type to include `'conductor'`
- Added 4 new permission types for event management:
  - `events:create`
  - `events:manage`
  - `events:delete`
  - `attendance:record`

**Permission Matrix:**
- Added conductor to `PERMISSIONS` matrix with event/attendance permissions
- Owner role continues to have all permissions (including conductor permissions)

**Helper Functions:**
- `canCreateEvents()`
- `canManageEvents()`
- `canDeleteEvents()`
- `canRecordAttendance()`

**Database:**
- Migration 0011: Updated `member_roles` CHECK constraint to include 'conductor'

**Tests:**
- 5 new test cases covering conductor permissions (TDD approach)
- All 139 vault tests passing

## TDD Workflow

✅ RED: Wrote 5 failing tests for conductor permissions
✅ GREEN: Implemented permissions to make tests pass
✅ REFACTOR: Added helper functions for cleaner API

## Next Steps

After merge:
- Issue #56: Update member management UI to support conductor role badge
- Issue #57: Implement calendar/events feature (use conductor permissions)

Closes #55