### PR TITLE
feat: Add E2E test database seeding (#87)

### DIFF
--- a/apps/vault/tests/e2e/seed-test-data.sql
+++ b/apps/vault/tests/e2e/seed-test-data.sql
@@ -1,0 +1,101 @@
+-- E2E Test Database Seed Data
+-- Run this before E2E tests to create test members that match fixtures.ts
+--
+-- Usage with wrangler:
+--   wrangler d1 execute DB --local --file=tests/e2e/seed-test-data.sql
+
+-- ============================================================================
+-- CLEANUP: Remove existing test data (idempotent)
+-- ============================================================================
+
+-- Delete test members (CASCADE will clean up junction tables)
+DELETE FROM member_roles WHERE member_id LIKE 'e2e-%';
+DELETE FROM member_voices WHERE member_id LIKE 'e2e-%';
+DELETE FROM member_sections WHERE member_id LIKE 'e2e-%';
+DELETE FROM members WHERE id LIKE 'e2e-%';
+
+-- Delete test invites
+DELETE FROM invite_voices WHERE invite_id LIKE 'e2e-%';
+DELETE FROM invite_sections WHERE invite_id LIKE 'e2e-%';
+DELETE FROM invites WHERE id LIKE 'e2e-%';
+
+-- ============================================================================
+-- SEED TEST MEMBERS (matching fixtures.ts)
+-- ============================================================================
+
+INSERT INTO members (id, email, name, invited_by, joined_at) VALUES
+    ('e2e-owner-001', 'owner@e2e-test.polyphony.app', 'E2E Owner', NULL, datetime('now')),
+    ('e2e-admin-001', 'admin@e2e-test.polyphony.app', 'E2E Admin', 'e2e-owner-001', datetime('now')),
+    ('e2e-librarian-001', 'librarian@e2e-test.polyphony.app', 'E2E Librarian', 'e2e-owner-001', datetime('now')),
+    ('e2e-singer-001', 'singer@e2e-test.polyphony.app', 'E2E Singer', 'e2e-admin-001', datetime('now'));
+
+-- ============================================================================
+-- SEED MEMBER ROLES
+-- ============================================================================
+
+-- Owner has owner role
+INSERT INTO member_roles (member_id, role, granted_at, granted_by) VALUES
+    ('e2e-owner-001', 'owner', datetime('now'), NULL);
+
+-- Admin has admin role
+INSERT INTO member_roles (member_id, role, granted_at, granted_by) VALUES
+    ('e2e-admin-001', 'admin', datetime('now'), 'e2e-owner-001');
+
+-- Librarian has librarian role
+INSERT INTO member_roles (member_id, role, granted_at, granted_by) VALUES
+    ('e2e-librarian-001', 'librarian', datetime('now'), 'e2e-owner-001');
+
+-- Singer has no special role (just a member)
+-- No INSERT needed - authenticated members have implicit view/download permissions
+
+-- ============================================================================
+-- SEED MEMBER VOICES (for testing voice badges)
+-- ============================================================================
+
+-- Owner: Soprano (primary)
+INSERT INTO member_voices (member_id, voice_id, is_primary, assigned_at, assigned_by) VALUES
+    ('e2e-owner-001', 'soprano', 1, datetime('now'), NULL);
+
+-- Admin: Alto (primary), Soprano (secondary)
+INSERT INTO member_voices (member_id, voice_id, is_primary, assigned_at, assigned_by) VALUES
+    ('e2e-admin-001', 'alto', 1, datetime('now'), 'e2e-owner-001'),
+    ('e2e-admin-001', 'soprano', 0, datetime('now'), 'e2e-owner-001');
+
+-- Librarian: Tenor (primary)
+INSERT INTO member_voices (member_id, voice_id, is_primary, assigned_at, assigned_by) VALUES
+    ('e2e-librarian-001', 'tenor', 1, datetime('now'), 'e2e-owner-001');
+
+-- Singer: Bass (primary), Baritone (secondary)
+INSERT INTO member_voices (member_id, voice_id, is_primary, assigned_at, assigned_by) VALUES
+    ('e2e-singer-001', 'bass', 1, datetime('now'), 'e2e-admin-001'),
+    ('e2e-singer-001', 'baritone', 0, datetime('now'), 'e2e-admin-001');
+
+-- ============================================================================
+-- SEED MEMBER SECTIONS (for testing section badges)
+-- ============================================================================
+
+-- Owner: Soprano section (primary)
+INSERT INTO member_sections (member_id, section_id, is_primary, joined_at, assigned_by) VALUES
+    ('e2e-owner-001', 'soprano', 1, datetime('now'), NULL);
+
+-- Admin: Alto section (primary)
+INSERT INTO member_sections (member_id, section_id, is_primary, joined_at, assigned_by) VALUES
+    ('e2e-admin-001', 'alto', 1, datetime('now'), 'e2e-owner-001');
+
+-- Librarian: Tenor section (primary)
+INSERT INTO member_sections (member_id, section_id, is_primary, joined_at, assigned_by) VALUES
+    ('e2e-librarian-001', 'tenor', 1, datetime('now'), 'e2e-owner-001');
+
+-- Singer: Bass section (primary)
+INSERT INTO member_sections (member_id, section_id, is_primary, joined_at, assigned_by) VALUES
+    ('e2e-singer-001', 'bass', 1, datetime('now'), 'e2e-admin-001');
+
+-- ============================================================================
+-- VERIFY: Quick check that data was inserted
+-- ============================================================================
+
+-- Uncomment these for debugging:
+-- SELECT 'Members:' as table_name, count(*) as count FROM members WHERE id LIKE 'e2e-%';
+-- SELECT 'Roles:' as table_name, count(*) as count FROM member_roles WHERE member_id LIKE 'e2e-%';
+-- SELECT 'Voices:' as table_name, count(*) as count FROM member_voices WHERE member_id LIKE 'e2e-%';
+-- SELECT 'Sections:' as table_name, count(*) as count FROM member_sections WHERE member_id LIKE 'e2e-%';

--- a/docs/DATABASE-SCHEMA.md
+++ b/docs/DATABASE-SCHEMA.md
@@ -1,12 +1,14 @@
 # Database Schema
 
-Vault D1 database schema (SQLite). Current state after migration 0001 (consolidated).
+Vault D1 database schema (SQLite). Current state after migrations 0001-0004.
 
 ## Entity-Relationship Diagram
 
 ```mermaid
 erDiagram
     members ||--o{ member_roles : "has"
+    members ||--o{ member_voices : "can sing"
+    members ||--o{ member_sections : "assigned to"
     members ||--o{ scores : "uploads"
     members ||--o{ invites : "invites"
     members ||--o{ takedowns : "processes"
@@ -15,28 +17,71 @@ erDiagram
     members ||--o{ events : "creates"
     members ||--o{ vault_settings : "updates"
 
+    voices ||--o{ member_voices : "assigned to"
+    voices ||--o{ invite_voices : "pre-assigned"
+    sections ||--o{ member_sections : "contains"
+    sections ||--o{ invite_sections : "pre-assigned"
+    sections ||--o{ sections : "parent of"
+
+    invites ||--o{ invite_voices : "includes"
+    invites ||--o{ invite_sections : "includes"
+
     scores ||--o{ score_files : "stored as"
     scores ||--o{ score_chunks : "chunked as"
     scores ||--o{ event_programs : "appears in"
 
     events ||--o{ event_programs : "contains"
 
-    invites ||--o{ member_roles : "grants"
-
     members {
         TEXT id PK
         TEXT email UK "NOT NULL"
         TEXT name
-        TEXT voice_part "SATB pattern"
         TEXT invited_by FK
         TEXT joined_at
     }
 
     member_roles {
         TEXT member_id PK,FK
-        TEXT role PK "owner|admin|librarian|conductor"
+        TEXT role PK "owner|admin|librarian|conductor|section_leader"
         TEXT granted_at
         TEXT granted_by FK
+    }
+
+    voices {
+        TEXT id PK
+        TEXT name UK "NOT NULL"
+        TEXT abbreviation "NOT NULL"
+        TEXT category "vocal|instrumental"
+        TEXT range_group "soprano|alto|tenor|bass|etc"
+        INTEGER display_order "NOT NULL"
+        INTEGER is_active "0|1"
+    }
+
+    sections {
+        TEXT id PK
+        TEXT name "NOT NULL"
+        TEXT abbreviation "NOT NULL"
+        TEXT parent_section_id FK
+        INTEGER display_order "NOT NULL"
+        INTEGER is_active "0|1"
+    }
+
+    member_voices {
+        TEXT member_id PK,FK
+        TEXT voice_id PK,FK
+        INTEGER is_primary "0|1"
+        TEXT assigned_at
+        TEXT assigned_by FK
+        TEXT notes
+    }
+
+    member_sections {
+        TEXT member_id PK,FK
+        TEXT section_id PK,FK
+        INTEGER is_primary "0|1"
+        TEXT joined_at
+        TEXT assigned_by FK
+        TEXT notes
     }
 
     scores {
@@ -71,15 +116,26 @@ erDiagram
     invites {
         TEXT id PK
         TEXT name "NOT NULL"
-        TEXT token "NOT NULL"
+        TEXT token UK "NOT NULL"
         TEXT invited_by FK
         TEXT expires_at "NOT NULL"
-        TEXT status "pending|accepted|expired"
+        TEXT status "pending|accepted"
         TEXT roles "JSON array"
-        TEXT voice_part
         TEXT created_at
         TEXT accepted_at
         TEXT accepted_by_email "Registry-verified"
+    }
+
+    invite_voices {
+        TEXT invite_id PK,FK
+        TEXT voice_id PK,FK
+        INTEGER is_primary "0|1"
+    }
+
+    invite_sections {
+        TEXT invite_id PK,FK
+        TEXT section_id PK,FK
+        INTEGER is_primary "0|1"
     }
 
     vault_settings {
@@ -144,16 +200,17 @@ erDiagram
 
 Vault members (authenticated users).
 
-| Column     | Type | Constraints      | Description                                            |
-| ---------- | ---- | ---------------- | ------------------------------------------------------ |
-| id         | TEXT | PK               | Unique member ID                                       |
-| email      | TEXT | NOT NULL, UNIQUE | Email from Registry                                    |
-| name       | TEXT |                  | Display name                                           |
-| voice_part | TEXT | CHECK            | Voice section: `[SATB]{1,4}` (e.g., `S`, `AT`, `SATB`) |
-| invited_by | TEXT | FK → members(id) | Who invited this member                                |
-| joined_at  | TEXT | DEFAULT now()    | Timestamp                                              |
+| Column     | Type | Constraints      | Description             |
+| ---------- | ---- | ---------------- | ----------------------- |
+| id         | TEXT | PK               | Unique member ID        |
+| email      | TEXT | NOT NULL, UNIQUE | Email from Registry     |
+| name       | TEXT |                  | Display name            |
+| invited_by | TEXT | FK → members(id) | Who invited this member |
+| joined_at  | TEXT | DEFAULT now()    | Timestamp               |
 
 **Indexes:** None additional (PK on id, UNIQUE on email)
+
+**Note:** Voice capabilities and section assignments are stored in junction tables `member_voices` and `member_sections`.
 
 ---
 
@@ -161,12 +218,12 @@ Vault members (authenticated users).
 
 Multi-role support via junction table.
 
-| Column     | Type | Constraints          | Description                                |
-| ---------- | ---- | -------------------- | ------------------------------------------ |
-| member_id  | TEXT | PK, FK → members(id) | Member reference                           |
-| role       | TEXT | PK, CHECK            | `owner`, `admin`, `librarian`, `conductor` |
-| granted_at | TEXT | DEFAULT now()        | When role assigned                         |
-| granted_by | TEXT | FK → members(id)     | Who granted role                           |
+| Column     | Type | Constraints          | Description                                                  |
+| ---------- | ---- | -------------------- | ------------------------------------------------------------ |
+| member_id  | TEXT | PK, FK → members(id) | Member reference                                             |
+| role       | TEXT | PK, CHECK            | `owner`, `admin`, `librarian`, `conductor`, `section_leader` |
+| granted_at | TEXT | DEFAULT now()        | When role assigned                                           |
+| granted_by | TEXT | FK → members(id)     | Who granted role                                             |
 
 **Indexes:**
 
@@ -179,6 +236,105 @@ Multi-role support via junction table.
 - Owner role is protected (cannot remove last owner)
 
 ---
+
+### Voices and Sections
+
+#### voices
+
+Vocal capabilities that members can have (what they CAN sing).
+
+| Column        | Type    | Constraints         | Description                           |
+| ------------- | ------- | ------------------- | ------------------------------------- |
+| id            | TEXT    | PK                  | Voice ID (e.g., 'soprano', 'tenor')   |
+| name          | TEXT    | NOT NULL, UNIQUE    | Display name                          |
+| abbreviation  | TEXT    | NOT NULL            | Short code (e.g., 'S', 'T')           |
+| category      | TEXT    | CHECK               | `vocal` or `instrumental`             |
+| range_group   | TEXT    |                     | Grouping (soprano, alto, tenor, bass) |
+| display_order | INTEGER | NOT NULL            | Sort order for UI                     |
+| is_active     | INTEGER | NOT NULL, DEFAULT 1 | 0=hidden, 1=available                 |
+
+**Indexes:**
+
+- `idx_voices_category` on category
+- `idx_voices_display_order` on display_order
+
+**Seeded Data:** Soprano, Alto, Tenor, Baritone, Bass (active); subdivisions like Soprano I, Soprano II (inactive by default)
+
+---
+
+#### sections
+
+Performance assignments (where members DO sing in a particular piece/season).
+
+| Column            | Type    | Constraints         | Description                             |
+| ----------------- | ------- | ------------------- | --------------------------------------- |
+| id                | TEXT    | PK                  | Section ID (e.g., 'soprano', 'tenor-1') |
+| name              | TEXT    | NOT NULL            | Display name                            |
+| abbreviation      | TEXT    | NOT NULL            | Short code (e.g., 'S', 'T1')            |
+| parent_section_id | TEXT    | FK → sections(id)   | Parent section for subdivisions         |
+| display_order     | INTEGER | NOT NULL            | Sort order for UI                       |
+| is_active         | INTEGER | NOT NULL, DEFAULT 1 | 0=hidden, 1=available                   |
+
+**Indexes:**
+
+- `idx_sections_display_order` on display_order
+- `idx_sections_parent` on parent_section_id
+
+**Seeded Data:** Mirrors voices structure with parent relationships for subdivisions
+
+---
+
+#### member_voices
+
+Junction table: which voices each member can sing.
+
+| Column      | Type    | Constraints                            | Description                   |
+| ----------- | ------- | -------------------------------------- | ----------------------------- |
+| member_id   | TEXT    | PK, FK → members(id) ON DELETE CASCADE | Member reference              |
+| voice_id    | TEXT    | PK, FK → voices(id) ON DELETE CASCADE  | Voice reference               |
+| is_primary  | INTEGER | NOT NULL, DEFAULT 0, CHECK 0\|1        | Primary voice for this member |
+| assigned_at | TEXT    | DEFAULT now()                          | When assigned                 |
+| assigned_by | TEXT    | FK → members(id)                       | Who assigned                  |
+| notes       | TEXT    |                                        | Optional notes                |
+
+**Indexes:**
+
+- `idx_member_voices_member` on member_id
+- `idx_member_voices_voice` on voice_id
+- `idx_member_voices_primary` on is_primary WHERE is_primary = 1
+
+**Triggers:**
+
+- `enforce_single_primary_voice` - Ensures only one primary voice per member
+
+---
+
+#### member_sections
+
+Junction table: which sections each member is assigned to.
+
+| Column      | Type    | Constraints                             | Description                     |
+| ----------- | ------- | --------------------------------------- | ------------------------------- |
+| member_id   | TEXT    | PK, FK → members(id) ON DELETE CASCADE  | Member reference                |
+| section_id  | TEXT    | PK, FK → sections(id) ON DELETE CASCADE | Section reference               |
+| is_primary  | INTEGER | NOT NULL, DEFAULT 0, CHECK 0\|1         | Primary section for this member |
+| joined_at   | TEXT    | DEFAULT now()                           | When assigned                   |
+| assigned_by | TEXT    | FK → members(id)                        | Who assigned                    |
+| notes       | TEXT    |                                         | Optional notes                  |
+
+**Indexes:**
+
+- `idx_member_sections_member` on member_id
+- `idx_member_sections_section` on section_id
+- `idx_member_sections_primary` on is_primary WHERE is_primary = 1
+
+**Triggers:**
+
+- `enforce_single_primary_section` - Ensures only one primary section per member
+
+---
+
+### Scores
 
 #### scores
 
@@ -242,11 +398,11 @@ Large file storage (>2MB files split into chunks).
 
 ---
 
-### Supporting Tables
+### Invitations
 
 #### invites
 
-Pending member invitations (name-based, multi-role support).
+Pending member invitations (name-based, multi-role support, with pre-assigned voices/sections).
 
 | Column            | Type | Constraints      | Description                                    |
 | ----------------- | ---- | ---------------- | ---------------------------------------------- |
@@ -255,9 +411,8 @@ Pending member invitations (name-based, multi-role support).
 | token             | TEXT | NOT NULL, UNIQUE | Secret invite token                            |
 | invited_by        | TEXT | FK → members(id) | Inviter                                        |
 | expires_at        | TEXT | NOT NULL         | Expiration timestamp (48h default)             |
-| status            | TEXT | CHECK            | `pending`, `accepted`, `expired`               |
+| status            | TEXT | CHECK            | `pending`, `accepted`                          |
 | roles             | TEXT | NOT NULL         | JSON array of roles to grant                   |
-| voice_part        | TEXT | CHECK            | Voice part: `[SATB]{1,4}`                      |
 | created_at        | TEXT | DEFAULT now()    | Created timestamp                              |
 | accepted_at       | TEXT |                  | Acceptance timestamp                           |
 | accepted_by_email | TEXT |                  | Registry-verified email (filled on acceptance) |
@@ -270,10 +425,44 @@ Pending member invitations (name-based, multi-role support).
 **Notes:**
 
 - Email comes from Registry OAuth on acceptance (not stored in invite)
-- Multiple roles can be assigned via JSON array (migration 0008)
-- Name-based tracking (migration 0009)
+- Voices and sections are stored in `invite_voices` and `invite_sections` junction tables
+- On acceptance, voices/sections are transferred to `member_voices` and `member_sections`
 
 ---
+
+#### invite_voices
+
+Junction table: voices to assign when invite is accepted.
+
+| Column     | Type    | Constraints                            | Description                    |
+| ---------- | ------- | -------------------------------------- | ------------------------------ |
+| invite_id  | TEXT    | PK, FK → invites(id) ON DELETE CASCADE | Invite reference               |
+| voice_id   | TEXT    | PK, FK → voices(id) ON DELETE CASCADE  | Voice reference                |
+| is_primary | INTEGER | NOT NULL, DEFAULT 0                    | Will be primary for new member |
+
+**Indexes:**
+
+- `idx_invite_voices_invite` on invite_id
+
+---
+
+#### invite_sections
+
+Junction table: sections to assign when invite is accepted.
+
+| Column     | Type    | Constraints                             | Description                    |
+| ---------- | ------- | --------------------------------------- | ------------------------------ |
+| invite_id  | TEXT    | PK, FK → invites(id) ON DELETE CASCADE  | Invite reference               |
+| section_id | TEXT    | PK, FK → sections(id) ON DELETE CASCADE | Section reference              |
+| is_primary | INTEGER | NOT NULL, DEFAULT 0                     | Will be primary for new member |
+
+**Indexes:**
+
+- `idx_invite_sections_invite` on invite_id
+
+---
+
+### Supporting Tables
 
 #### sessions
 
@@ -346,11 +535,9 @@ Configuration settings for the vault (key-value store with audit trail).
 
 **Indexes:** None additional
 
-**Default settings** (migration 0010):
+**Default settings:**
 
-- `default_voice_part`: ''
 - `default_event_duration`: '120' (minutes)
-- `conductor_id`: ''
 
 ---
 
@@ -406,7 +593,15 @@ Setlists linking scores to events in order.
 
 ### Member → Roles (Many-to-Many)
 
-A member can have multiple roles (owner, admin, librarian). Authenticated membership implies basic "singer" permissions (view/download).
+A member can have multiple roles (owner, admin, librarian, conductor, section_leader). Authenticated membership implies basic "singer" permissions (view/download).
+
+### Member → Voices (Many-to-Many)
+
+A member can have multiple voice capabilities (e.g., can sing both Tenor and Baritone). One voice is marked as primary. Managed via `member_voices` junction table.
+
+### Member → Sections (Many-to-Many)
+
+A member can be assigned to multiple sections (e.g., Tenor I for most pieces, but Full Choir for others). One section is marked as primary. Managed via `member_sections` junction table.
 
 ### Member → Scores (One-to-Many)
 
@@ -418,7 +613,11 @@ Each score has 1 metadata row in `score_files`. Large files (>2MB) also have N r
 
 ### Member → Invites (One-to-Many)
 
-A member (admin/owner) can send multiple invitations. Invites create new members when accepted. Invites are name-based and can grant multiple roles via JSON array (migrations 0008-0009).
+A member (admin/owner) can send multiple invitations. Invites can pre-assign voices and sections that transfer to the new member on acceptance.
+
+### Section → Section (Self-referential)
+
+Sections can have parent sections (e.g., "Soprano I" is a child of "Soprano"). This allows hierarchical organization.
 
 ### Member → Events (One-to-Many)
 
@@ -429,13 +628,6 @@ Each event is created by one member (with conductor/owner role). Members can cre
 Each event has one program (setlist) with multiple scores. Scores are ordered by position.
 
 ## Data Constraints
-
-### Voice Part Pattern
-
-`voice_part` must match: `[SATB]{1,4}` (1-4 characters, only S/A/T/B)
-
-- Valid: `S`, `AT`, `SATB`, `TB`
-- Invalid: `SS`, `X`, `SATBR`
 
 ### License Types
 
@@ -449,7 +641,8 @@ Each event has one program (setlist) with multiple scores. Scores are ordered by
 - `owner` - Vault superuser (protected, at least 1 required)
 - `admin` - Member management
 - `librarian` - Score management
-- `conductor` - Event and attendance management (added migration 0011)
+- `conductor` - Event and attendance management
+- `section_leader` - Section-specific management
 
 ### Event Types
 
@@ -461,18 +654,18 @@ Each event has one program (setlist) with multiple scores. Scores are ordered by
 
 - `pending` - Invite created, not yet accepted
 - `accepted` - Invite used to create member
-- `expired` - Invite past expiration date
 
 ## Migration History
 
-| Migration | Description                                                                                                                                                                                                                                                                     |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **0001**  | **Complete schema** - Consolidated from production state (2026-01-26). Includes all tables: members, member_roles, scores, score_files, score_chunks, invites, sessions, takedowns, access_log, vault_settings, events, event_programs. Replaces broken incremental migrations. |
-
-**Note**: Previous migrations (0001-0012) were consolidated into a single migration on 2026-01-26 due to schema drift between development history and production state. The new 0001_complete_schema.sql represents the verified working state and is fully replayable from scratch.
+| Migration | Description                                                                                                                                                                                                                  |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **0001**  | **Complete schema** - Consolidated base schema with members, member_roles, scores, score_files, score_chunks, invites, sessions, takedowns, access_log, vault_settings, events, event_programs.                              |
+| **0002**  | **Section leader role** - Added `section_leader` to member_roles CHECK constraint.                                                                                                                                           |
+| **0003**  | **Voices and sections** - Added voices, sections, member_voices, member_sections, invite_voices, invite_sections tables. Removed voice_part columns from members and invites. Added triggers for single-primary enforcement. |
+| **0004**  | **Remove default_voice_part** - Removed deprecated setting from vault_settings.                                                                                                                                              |
 
 ## See Also
 
 - [roles.md](../apps/vault/docs/roles.md) - Role definitions and permissions
 - [migrations/](../apps/vault/migrations/) - SQL migration files
-- TypeScript interfaces: `../apps/vault/src/lib/server/db/members.ts`
+- TypeScript interfaces: `../apps/vault/src/lib/types.ts`


### PR DESCRIPTION
## Overview

Provides infrastructure for seeding test data before E2E tests, resolving the 42 failing E2E tests in  and .

## Changes

### 1. E2E Test Seed File ()

**Features:**
- ✅ **Idempotent**: Safe to run multiple times (cleans up before inserting)
- ✅ **E2E-prefixed IDs**: Easy identification and cleanup (`e2e-*` prefix)
- ✅ **Complete test data**:
  - 4 test members (owner, admin, librarian, singer)
  - Proper role assignments via `member_roles` junction table
  - Voice assignments (Soprano, Alto, Tenor, Bass with primary flags)
  - Section assignments (matching voices)

**Usage:**
```bash
wrangler d1 execute DB --local --file=tests/e2e/seed-test-data.sql
```

**Test Members Created:**
| ID | Email | Name | Role | Voice | Section |
|----|-------|------|------|-------|---------|
| e2e-owner-001 | owner@e2e-test.polyphony.app | E2E Owner | owner | Soprano★ | Soprano★ |
| e2e-admin-001 | admin@e2e-test.polyphony.app | E2E Admin | admin | Alto★, Soprano | Alto★ |
| e2e-librarian-001 | librarian@e2e-test.polyphony.app | E2E Librarian | librarian | Tenor★ | Tenor★ |
| e2e-singer-001 | singer@e2e-test.polyphony.app | E2E Singer | (none) | Bass★, Baritone | Bass★ |

★ = primary voice/section

### 2. Updated Schema Documentation ()

**Comprehensive schema update:**
- ✅ Added voices and sections tables (migration 0003)
- ✅ Added junction tables: `member_voices`, `member_sections`, `invite_voices`, `invite_sections`
- ✅ Updated ERD with new relationships
- ✅ Added complete table definitions with indexes and triggers
- ✅ Updated migration history (0001-0004)
- ✅ Removed all `voice_part` column references (replaced by junction tables)

## Testing

✅ **All 323 unit tests pass**
- packages/shared: 20 tests
- apps/registry: 62 tests
- apps/vault: 241 tests

✅ **TypeScript checks clean** (0 errors, 0 warnings)

## Next Steps

After merging, update E2E test setup:
1. Run seed file before E2E tests
2. Verify 42 failing tests now pass
3. Integrate into CI/CD pipeline

## Related

- Closes #87
- Related to Epic #73 (Flexible Voices & Sections System)
- Follows migrations #79 (0003), #80 (0004), #82 (cleanup)