### PR TITLE
feat(vault): Works CRUD for Score Library

### DIFF
--- a/apps/vault/migrations/0013_works.sql
+++ b/apps/vault/migrations/0013_works.sql
@@ -1,0 +1,14 @@
+-- Works table for Score Library (Epic #106)
+-- Abstract compositions with minimal metadata
+
+CREATE TABLE works (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  composer TEXT,
+  lyricist TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Index for search by title/composer
+CREATE INDEX idx_works_title ON works(title);
+CREATE INDEX idx_works_composer ON works(composer);

--- a/apps/vault/src/lib/server/auth/middleware.ts
+++ b/apps/vault/src/lib/server/auth/middleware.ts
@@ -103,6 +103,16 @@ export async function getAuthenticatedMember(
 }
 
 /**
+ * Assert member has librarian, admin, or owner role, throw 403 if not
+ */
+export function assertLibrarian(member: Member): void {
+	const isLibrarian = member.roles.some((r) => ['librarian', 'admin', 'owner'].includes(r));
+	if (!isLibrarian) {
+		throw error(403, 'Librarian, admin, or owner role required');
+	}
+}
+
+/**
  * Assert member has admin or owner role, throw 403 if not
  */
 export function assertAdmin(member: Member): void {

--- a/apps/vault/src/lib/server/db/works.spec.ts
+++ b/apps/vault/src/lib/server/db/works.spec.ts
@@ -1,0 +1,209 @@
+// Works database layer tests
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	createWork,
+	getWorkById,
+	getAllWorks,
+	updateWork,
+	deleteWork,
+	searchWorks
+} from './works';
+import type { Work } from '$lib/types';
+
+// Mock D1Database
+function createMockDb() {
+	const mockRun = vi.fn().mockResolvedValue({ meta: { changes: 1 } });
+	const mockFirst = vi.fn();
+	const mockAll = vi.fn().mockResolvedValue({ results: [] });
+	const mockBind = vi.fn().mockReturnThis();
+
+	return {
+		prepare: vi.fn().mockReturnValue({
+			bind: mockBind,
+			run: mockRun,
+			first: mockFirst,
+			all: mockAll
+		}),
+		_mocks: { mockRun, mockFirst, mockAll, mockBind }
+	} as unknown as D1Database & { _mocks: typeof import('vitest') };
+}
+
+describe('Works database layer', () => {
+	let db: ReturnType<typeof createMockDb>;
+
+	beforeEach(() => {
+		db = createMockDb();
+	});
+
+	describe('createWork', () => {
+		it('creates a work with title only', async () => {
+			const work = await createWork(db, { title: 'Messiah' });
+
+			expect(work.title).toBe('Messiah');
+			expect(work.composer).toBeNull();
+			expect(work.lyricist).toBeNull();
+			expect(work.id).toBeDefined();
+			expect(work.createdAt).toBeDefined();
+		});
+
+		it('creates a work with all fields', async () => {
+			const work = await createWork(db, {
+				title: 'Messiah',
+				composer: 'Handel',
+				lyricist: 'Jennens'
+			});
+
+			expect(work.title).toBe('Messiah');
+			expect(work.composer).toBe('Handel');
+			expect(work.lyricist).toBe('Jennens');
+		});
+
+		it('generates unique IDs', async () => {
+			const work1 = await createWork(db, { title: 'Work 1' });
+			const work2 = await createWork(db, { title: 'Work 2' });
+
+			expect(work1.id).not.toBe(work2.id);
+		});
+	});
+
+	describe('getWorkById', () => {
+		it('returns work when found', async () => {
+			const mockRow = {
+				id: 'work-123',
+				title: 'Messiah',
+				composer: 'Handel',
+				lyricist: null,
+				created_at: '2026-01-29T12:00:00Z'
+			};
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockRow);
+
+			const work = await getWorkById(db, 'work-123');
+
+			expect(work).not.toBeNull();
+			expect(work?.title).toBe('Messiah');
+			expect(work?.composer).toBe('Handel');
+			expect(work?.lyricist).toBeNull();
+		});
+
+		it('returns null when not found', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+			const work = await getWorkById(db, 'nonexistent');
+
+			expect(work).toBeNull();
+		});
+	});
+
+	describe('getAllWorks', () => {
+		it('returns empty array when no works', async () => {
+			const works = await getAllWorks(db);
+
+			expect(works).toEqual([]);
+		});
+
+		it('returns all works ordered by title', async () => {
+			const mockRows = [
+				{ id: '1', title: 'Ave Maria', composer: 'Schubert', lyricist: null, created_at: '2026-01-29' },
+				{ id: '2', title: 'Messiah', composer: 'Handel', lyricist: 'Jennens', created_at: '2026-01-29' }
+			];
+			(db.prepare('').all as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ results: mockRows });
+
+			const works = await getAllWorks(db);
+
+			expect(works).toHaveLength(2);
+			expect(works[0].title).toBe('Ave Maria');
+			expect(works[1].title).toBe('Messiah');
+		});
+	});
+
+	describe('updateWork', () => {
+		it('updates work title', async () => {
+			const mockRow = {
+				id: 'work-123',
+				title: 'Updated Title',
+				composer: 'Handel',
+				lyricist: null,
+				created_at: '2026-01-29T12:00:00Z'
+			};
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockRow);
+
+			const work = await updateWork(db, 'work-123', { title: 'Updated Title' });
+
+			expect(work?.title).toBe('Updated Title');
+		});
+
+		it('clears optional fields when set to null', async () => {
+			const mockRow = {
+				id: 'work-123',
+				title: 'Messiah',
+				composer: null,
+				lyricist: null,
+				created_at: '2026-01-29T12:00:00Z'
+			};
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockRow);
+
+			const work = await updateWork(db, 'work-123', { composer: null });
+
+			expect(work?.composer).toBeNull();
+		});
+
+		it('returns null when work not found', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ meta: { changes: 0 } });
+
+			const work = await updateWork(db, 'nonexistent', { title: 'New Title' });
+
+			expect(work).toBeNull();
+		});
+	});
+
+	describe('deleteWork', () => {
+		it('deletes existing work', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ meta: { changes: 1 } });
+
+			const deleted = await deleteWork(db, 'work-123');
+
+			expect(deleted).toBe(true);
+		});
+
+		it('returns false when work not found', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ meta: { changes: 0 } });
+
+			const deleted = await deleteWork(db, 'nonexistent');
+
+			expect(deleted).toBe(false);
+		});
+	});
+
+	describe('searchWorks', () => {
+		it('searches by title', async () => {
+			const mockRows = [
+				{ id: '1', title: 'Messiah', composer: 'Handel', lyricist: null, created_at: '2026-01-29' }
+			];
+			(db.prepare('').all as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ results: mockRows });
+
+			const works = await searchWorks(db, 'mess');
+
+			expect(works).toHaveLength(1);
+			expect(works[0].title).toBe('Messiah');
+		});
+
+		it('searches by composer', async () => {
+			const mockRows = [
+				{ id: '1', title: 'Messiah', composer: 'Handel', lyricist: null, created_at: '2026-01-29' }
+			];
+			(db.prepare('').all as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ results: mockRows });
+
+			const works = await searchWorks(db, 'handel');
+
+			expect(works).toHaveLength(1);
+		});
+
+		it('returns empty array for no matches', async () => {
+			(db.prepare('').all as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ results: [] });
+
+			const works = await searchWorks(db, 'xyz');
+
+			expect(works).toEqual([]);
+		});
+	});
+});

--- a/apps/vault/src/lib/server/db/works.ts
+++ b/apps/vault/src/lib/server/db/works.ts
@@ -1,0 +1,153 @@
+// Works database operations
+import type { Work, CreateWorkInput, UpdateWorkInput } from '$lib/types';
+
+interface WorkRow {
+	id: string;
+	title: string;
+	composer: string | null;
+	lyricist: string | null;
+	created_at: string;
+}
+
+/**
+ * Convert database row to Work interface (snake_case → camelCase)
+ */
+function rowToWork(row: WorkRow): Work {
+	return {
+		id: row.id,
+		title: row.title,
+		composer: row.composer,
+		lyricist: row.lyricist,
+		createdAt: row.created_at
+	};
+}
+
+/**
+ * Generate a unique ID for a work
+ */
+function generateId(): string {
+	return crypto.randomUUID().replace(/-/g, '').slice(0, 21);
+}
+
+/**
+ * Create a new work
+ */
+export async function createWork(db: D1Database, input: CreateWorkInput): Promise<Work> {
+	const id = generateId();
+	const now = new Date().toISOString();
+	const composer = input.composer ?? null;
+	const lyricist = input.lyricist ?? null;
+
+	await db
+		.prepare('INSERT INTO works (id, title, composer, lyricist, created_at) VALUES (?, ?, ?, ?, ?)')
+		.bind(id, input.title, composer, lyricist, now)
+		.run();
+
+	return {
+		id,
+		title: input.title,
+		composer,
+		lyricist,
+		createdAt: now
+	};
+}
+
+/**
+ * Get a work by ID
+ */
+export async function getWorkById(db: D1Database, id: string): Promise<Work | null> {
+	const row = await db
+		.prepare('SELECT id, title, composer, lyricist, created_at FROM works WHERE id = ?')
+		.bind(id)
+		.first<WorkRow>();
+
+	return row ? rowToWork(row) : null;
+}
+
+/**
+ * Get all works ordered by title
+ */
+export async function getAllWorks(db: D1Database): Promise<Work[]> {
+	const { results } = await db
+		.prepare('SELECT id, title, composer, lyricist, created_at FROM works ORDER BY title ASC')
+		.all<WorkRow>();
+
+	return results.map(rowToWork);
+}
+
+/**
+ * Update a work
+ * Returns the updated work, or null if not found
+ */
+export async function updateWork(
+	db: D1Database,
+	id: string,
+	input: UpdateWorkInput
+): Promise<Work | null> {
+	// Build SET clause dynamically based on provided fields
+	const updates: string[] = [];
+	const values: (string | null)[] = [];
+
+	if (input.title !== undefined) {
+		updates.push('title = ?');
+		values.push(input.title);
+	}
+	if (input.composer !== undefined) {
+		updates.push('composer = ?');
+		values.push(input.composer);
+	}
+	if (input.lyricist !== undefined) {
+		updates.push('lyricist = ?');
+		values.push(input.lyricist);
+	}
+
+	if (updates.length === 0) {
+		// No updates, just return current state
+		return getWorkById(db, id);
+	}
+
+	values.push(id);
+
+	const result = await db
+		.prepare(`UPDATE works SET ${updates.join(', ')} WHERE id = ?`)
+		.bind(...values)
+		.run();
+
+	if ((result.meta.changes ?? 0) === 0) {
+		return null;
+	}
+
+	return getWorkById(db, id);
+}
+
+/**
+ * Delete a work
+ * Returns true if deleted, false if not found
+ */
+export async function deleteWork(db: D1Database, id: string): Promise<boolean> {
+	const result = await db
+		.prepare('DELETE FROM works WHERE id = ?')
+		.bind(id)
+		.run();
+
+	return (result.meta.changes ?? 0) > 0;
+}
+
+/**
+ * Search works by title or composer (case-insensitive)
+ */
+export async function searchWorks(db: D1Database, query: string): Promise<Work[]> {
+	const pattern = `%${query}%`;
+
+	const { results } = await db
+		.prepare(`
+			SELECT id, title, composer, lyricist, created_at 
+			FROM works 
+			WHERE title LIKE ? OR composer LIKE ?
+			ORDER BY title ASC
+		`)
+		.bind(pattern, pattern)
+		.all<WorkRow>();
+
+	return results.map(rowToWork);
+}

--- a/apps/vault/src/lib/types.ts
+++ b/apps/vault/src/lib/types.ts
@@ -253,3 +253,37 @@ export interface RosterViewFilters {
 	end?: string; // ISO datetime
 	sectionId?: string; // Filter members by section
 }
+
+// ============================================================================
+// SCORE LIBRARY SYSTEM (Epic #106)
+// ============================================================================
+
+/**
+ * Work: Abstract composition (independent of specific publications)
+ * Example: "Messiah" by Handel (may have many Editions)
+ */
+export interface Work {
+	id: string;
+	title: string;
+	composer: string | null;
+	lyricist: string | null;
+	createdAt: string;
+}
+
+/**
+ * Input for creating a new work
+ */
+export interface CreateWorkInput {
+	title: string;
+	composer?: string;
+	lyricist?: string;
+}
+
+/**
+ * Input for updating a work
+ */
+export interface UpdateWorkInput {
+	title?: string;
+	composer?: string | null;
+	lyricist?: string | null;
+}

--- a/apps/vault/src/routes/api/works/+server.ts
+++ b/apps/vault/src/routes/api/works/+server.ts
@@ -1,0 +1,57 @@
+// API endpoint for works collection operations
+// GET /api/works - List all works (with optional search)
+// POST /api/works - Create a new work
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { getAuthenticatedMember, assertLibrarian } from '$lib/server/auth/middleware';
+import { createWork, getAllWorks, searchWorks } from '$lib/server/db/works';
+import type { CreateWorkInput } from '$lib/types';
+
+export async function GET({ url, platform, cookies }: RequestEvent) {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	// Auth: any authenticated member can view works
+	await getAuthenticatedMember(db, cookies);
+
+	// Check for search query
+	const query = url.searchParams.get('q');
+	
+	if (query && query.trim().length > 0) {
+		const works = await searchWorks(db, query.trim());
+		return json(works);
+	}
+
+	const works = await getAllWorks(db);
+	return json(works);
+}
+
+export async function POST({ request, platform, cookies }: RequestEvent) {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	// Auth: require librarian role to create works
+	const member = await getAuthenticatedMember(db, cookies);
+	assertLibrarian(member);
+
+	// Parse request body
+	const body = (await request.json()) as Partial<CreateWorkInput>;
+
+	// Validate required fields
+	if (!body.title || typeof body.title !== 'string' || body.title.trim().length === 0) {
+		return json({ error: 'Title is required' }, { status: 400 });
+	}
+
+	// Build input
+	const input: CreateWorkInput = {
+		title: body.title.trim(),
+		composer: typeof body.composer === 'string' ? body.composer.trim() || undefined : undefined,
+		lyricist: typeof body.lyricist === 'string' ? body.lyricist.trim() || undefined : undefined
+	};
+
+	const work = await createWork(db, input);
+	return json(work, { status: 201 });
+}

--- a/apps/vault/src/routes/api/works/[id]/+server.ts
+++ b/apps/vault/src/routes/api/works/[id]/+server.ts
@@ -1,0 +1,107 @@
+// API endpoint for individual work operations
+// GET /api/works/[id] - Get a work by ID
+// PATCH /api/works/[id] - Update a work
+// DELETE /api/works/[id] - Delete a work
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { getAuthenticatedMember, assertLibrarian } from '$lib/server/auth/middleware';
+import { getWorkById, updateWork, deleteWork } from '$lib/server/db/works';
+import type { UpdateWorkInput } from '$lib/types';
+
+export async function GET({ params, platform, cookies }: RequestEvent) {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	// Auth: any authenticated member can view works
+	await getAuthenticatedMember(db, cookies);
+
+	const workId = params.id;
+	if (!workId) {
+		throw error(400, 'Work ID is required');
+	}
+
+	const work = await getWorkById(db, workId);
+	if (!work) {
+		throw error(404, 'Work not found');
+	}
+
+	return json(work);
+}
+
+export async function PATCH({ params, request, platform, cookies }: RequestEvent) {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	// Auth: require librarian role to update works
+	const member = await getAuthenticatedMember(db, cookies);
+	assertLibrarian(member);
+
+	const workId = params.id;
+	if (!workId) {
+		throw error(400, 'Work ID is required');
+	}
+
+	// Parse request body
+	const body = (await request.json()) as Partial<UpdateWorkInput>;
+
+	// Build update input (only include provided fields)
+	const input: UpdateWorkInput = {};
+	
+	if (body.title !== undefined) {
+		if (typeof body.title !== 'string' || body.title.trim().length === 0) {
+			return json({ error: 'Title cannot be empty' }, { status: 400 });
+		}
+		input.title = body.title.trim();
+	}
+	
+	if (body.composer !== undefined) {
+		// Allow null to clear, or string value
+		if (body.composer === null) {
+			input.composer = null;
+		} else if (typeof body.composer === 'string') {
+			input.composer = body.composer.trim() || null;
+		}
+	}
+	
+	if (body.lyricist !== undefined) {
+		// Allow null to clear, or string value
+		if (body.lyricist === null) {
+			input.lyricist = null;
+		} else if (typeof body.lyricist === 'string') {
+			input.lyricist = body.lyricist.trim() || null;
+		}
+	}
+
+	const work = await updateWork(db, workId, input);
+	if (!work) {
+		throw error(404, 'Work not found');
+	}
+
+	return json(work);
+}
+
+export async function DELETE({ params, platform, cookies }: RequestEvent) {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	// Auth: require librarian role to delete works
+	const member = await getAuthenticatedMember(db, cookies);
+	assertLibrarian(member);
+
+	const workId = params.id;
+	if (!workId) {
+		throw error(400, 'Work ID is required');
+	}
+
+	const deleted = await deleteWork(db, workId);
+	if (!deleted) {
+		throw error(404, 'Work not found');
+	}
+
+	return json({ success: true });
+}

--- a/apps/vault/src/routes/works/+page.server.ts
+++ b/apps/vault/src/routes/works/+page.server.ts
@@ -1,0 +1,35 @@
+import type { PageServerLoad } from './$types';
+import { getMemberById } from '$lib/server/db/members';
+import { canUploadScores } from '$lib/server/auth/permissions';
+
+interface WorksResponse {
+	id: string;
+	title: string;
+	composer: string | null;
+	lyricist: string | null;
+	createdAt: string;
+}
+
+export const load: PageServerLoad = async ({ fetch, platform, cookies }) => {
+	const response = await fetch('/api/works');
+	const works = (await response.json()) as WorksResponse[];
+
+	// Get current user's permissions (librarian can manage works)
+	let canManage = false;
+
+	const db = platform?.env?.DB;
+	const memberId = cookies.get('member_id');
+
+	if (db && memberId) {
+		const member = await getMemberById(db, memberId);
+		if (member) {
+			// Librarians, admins, and owners can manage works
+			canManage = canUploadScores(member);
+		}
+	}
+
+	return {
+		works: works ?? [],
+		canManage
+	};
+};

--- a/apps/vault/src/routes/works/+page.svelte
+++ b/apps/vault/src/routes/works/+page.svelte
@@ -1,0 +1,317 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import type { PageData } from './$types';
+	import type { Work } from '$lib/types';
+
+	let { data }: { data: PageData } = $props();
+
+	// Local state
+	let works = $state<Work[]>(untrack(() => data.works));
+	let searchQuery = $state('');
+	let showCreateForm = $state(false);
+	let editingWork = $state<Work | null>(null);
+	let deletingId = $state<string | null>(null);
+	let saving = $state(false);
+	let error = $state('');
+	let success = $state('');
+
+	// Form state
+	let formTitle = $state('');
+	let formComposer = $state('');
+	let formLyricist = $state('');
+
+	// Sync with data on navigation
+	$effect(() => {
+		works = data.works;
+	});
+
+	let filteredWorks = $derived(
+		works.filter(
+			(w) =>
+				w.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+				(w.composer?.toLowerCase().includes(searchQuery.toLowerCase()) ?? false) ||
+				(w.lyricist?.toLowerCase().includes(searchQuery.toLowerCase()) ?? false)
+		)
+	);
+
+	function openCreateForm() {
+		formTitle = '';
+		formComposer = '';
+		formLyricist = '';
+		editingWork = null;
+		showCreateForm = true;
+	}
+
+	function openEditForm(work: Work) {
+		formTitle = work.title;
+		formComposer = work.composer ?? '';
+		formLyricist = work.lyricist ?? '';
+		editingWork = work;
+		showCreateForm = true;
+	}
+
+	function closeForm() {
+		showCreateForm = false;
+		editingWork = null;
+		formTitle = '';
+		formComposer = '';
+		formLyricist = '';
+	}
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		
+		if (!formTitle.trim()) {
+			error = 'Title is required';
+			return;
+		}
+
+		saving = true;
+		error = '';
+
+		try {
+			if (editingWork) {
+				// Update existing work
+				const response = await fetch(`/api/works/${editingWork.id}`, {
+					method: 'PATCH',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						title: formTitle.trim(),
+						composer: formComposer.trim() || null,
+						lyricist: formLyricist.trim() || null
+					})
+				});
+
+				if (!response.ok) {
+					const data = (await response.json()) as { error?: string };
+					throw new Error(data.error ?? 'Failed to update work');
+				}
+
+				const updated = (await response.json()) as Work;
+				works = works.map((w) => (w.id === updated.id ? updated : w));
+				success = `"${updated.title}" updated successfully`;
+			} else {
+				// Create new work
+				const response = await fetch('/api/works', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						title: formTitle.trim(),
+						composer: formComposer.trim() || undefined,
+						lyricist: formLyricist.trim() || undefined
+					})
+				});
+
+				if (!response.ok) {
+					const data = (await response.json()) as { error?: string };
+					throw new Error(data.error ?? 'Failed to create work');
+				}
+
+				const created = (await response.json()) as Work;
+				works = [...works, created].sort((a, b) => a.title.localeCompare(b.title));
+				success = `"${created.title}" created successfully`;
+			}
+
+			closeForm();
+			setTimeout(() => (success = ''), 3000);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Operation failed';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deleteWork(work: Work) {
+		if (!confirm(`Delete "${work.title}"? This cannot be undone.`)) return;
+
+		deletingId = work.id;
+		error = '';
+
+		try {
+			const response = await fetch(`/api/works/${work.id}`, { method: 'DELETE' });
+
+			if (!response.ok) {
+				const data = (await response.json()) as { error?: string };
+				throw new Error(data.error ?? 'Failed to delete work');
+			}
+
+			works = works.filter((w) => w.id !== work.id);
+			success = `"${work.title}" deleted`;
+			setTimeout(() => (success = ''), 3000);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Delete failed';
+		} finally {
+			deletingId = null;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Works Catalog | Polyphony Vault</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl px-4 py-8">
+	<div class="mb-8 flex items-center justify-between">
+		<div>
+			<h1 class="text-3xl font-bold">Works Catalog</h1>
+			<p class="mt-1 text-gray-600">Musical compositions in your library</p>
+		</div>
+		{#if data.canManage}
+			<button
+				onclick={openCreateForm}
+				class="rounded-lg bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700"
+			>
+				+ Add Work
+			</button>
+		{/if}
+	</div>
+
+	{#if error}
+		<div class="mb-4 rounded-lg bg-red-100 p-4 text-red-700">
+			{error}
+			<button onclick={() => (error = '')} class="ml-2 text-red-900 hover:underline">×</button>
+		</div>
+	{/if}
+
+	{#if success}
+		<div class="mb-4 rounded-lg bg-green-100 p-4 text-green-700">
+			{success}
+		</div>
+	{/if}
+
+	<!-- Create/Edit Form Modal -->
+	{#if showCreateForm}
+		<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+			<div class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+				<h2 class="mb-4 text-xl font-semibold">
+					{editingWork ? 'Edit Work' : 'Add New Work'}
+				</h2>
+				<form onsubmit={handleSubmit}>
+					<div class="mb-4">
+						<label for="title" class="mb-1 block text-sm font-medium text-gray-700">
+							Title <span class="text-red-500">*</span>
+						</label>
+						<input
+							id="title"
+							type="text"
+							bind:value={formTitle}
+							class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+							placeholder="e.g., Messiah"
+							required
+						/>
+					</div>
+					<div class="mb-4">
+						<label for="composer" class="mb-1 block text-sm font-medium text-gray-700">
+							Composer
+						</label>
+						<input
+							id="composer"
+							type="text"
+							bind:value={formComposer}
+							class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+							placeholder="e.g., G.F. Handel"
+						/>
+					</div>
+					<div class="mb-6">
+						<label for="lyricist" class="mb-1 block text-sm font-medium text-gray-700">
+							Lyricist / Librettist
+						</label>
+						<input
+							id="lyricist"
+							type="text"
+							bind:value={formLyricist}
+							class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+							placeholder="e.g., Charles Jennens"
+						/>
+					</div>
+					<div class="flex justify-end gap-3">
+						<button
+							type="button"
+							onclick={closeForm}
+							class="rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-50"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							disabled={saving}
+							class="rounded-lg bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700 disabled:opacity-50"
+						>
+							{saving ? 'Saving...' : editingWork ? 'Update' : 'Create'}
+						</button>
+					</div>
+				</form>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Search -->
+	<div class="mb-6">
+		<input
+			type="text"
+			bind:value={searchQuery}
+			placeholder="Search by title, composer, or lyricist..."
+			class="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+		/>
+	</div>
+
+	<!-- Works List -->
+	{#if filteredWorks.length === 0}
+		<div class="py-12 text-center text-gray-500">
+			{#if works.length === 0}
+				<p class="text-lg">No works in your catalog yet.</p>
+				{#if data.canManage}
+					<p class="mt-2">
+						<button onclick={openCreateForm} class="text-blue-600 hover:underline">
+							Add your first work
+						</button>
+					</p>
+				{/if}
+			{:else}
+				<p>No works match your search.</p>
+			{/if}
+		</div>
+	{:else}
+		<div class="space-y-4">
+			{#each filteredWorks as work (work.id)}
+				<div
+					class="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+				>
+					<div class="flex-1">
+						<h2 class="text-lg font-semibold">{work.title}</h2>
+						{#if work.composer}
+							<p class="text-gray-600">{work.composer}</p>
+						{/if}
+						{#if work.lyricist}
+							<p class="text-sm text-gray-500">text: {work.lyricist}</p>
+						{/if}
+						<p class="mt-1 text-xs text-gray-400">
+							Added {new Date(work.createdAt).toLocaleDateString()}
+						</p>
+					</div>
+					{#if data.canManage}
+						<div class="flex gap-2">
+							<button
+								onclick={() => openEditForm(work)}
+								class="rounded-lg bg-gray-100 px-3 py-2 text-gray-700 transition hover:bg-gray-200"
+							>
+								Edit
+							</button>
+							<button
+								onclick={() => deleteWork(work)}
+								disabled={deletingId === work.id}
+								class="rounded-lg bg-red-100 px-3 py-2 text-red-700 transition hover:bg-red-200 disabled:opacity-50"
+							>
+								{deletingId === work.id ? '...' : 'Delete'}
+							</button>
+						</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	<p class="mt-6 text-sm text-gray-500">
+		{filteredWorks.length} of {works.length} works
+	</p>
+</div>


### PR DESCRIPTION
## Summary
Implements the foundational Works CRUD layer for the Score Library (Epic #106).

## Changes

### Database Layer (#107)
- Migration `0013_works.sql` - creates works table with title, composer, lyricist
- `works.ts` - CRUD operations: createWork, getWorkById, getAllWorks, updateWork, deleteWork, searchWorks
- `works.spec.ts` - 15 comprehensive tests

### API Endpoints (#108)
- `GET /api/works` - List all works (with optional `?q=` search)
- `POST /api/works` - Create a new work (requires librarian role)
- `GET /api/works/[id]` - Get single work
- `PATCH /api/works/[id]` - Update work (requires librarian role)
- `DELETE /api/works/[id]` - Delete work (requires librarian role)
- Added `assertLibrarian` middleware helper

### Management UI (#109)
- `/works` route with search, create, edit, delete functionality
- Modal form for create/edit
- Permission-aware UI (only librarians/admins/owners see management buttons)

## Testing
All 451 tests pass (20 shared + 62 registry + 369 vault).

## Closes
- Closes #107
- Closes #108
- Closes #109