### PR TITLE
feat(#133): Add Physical Copies & Assignment UI to Edition page

### DIFF
--- a/apps/vault/src/routes/editions/[id]/+page.server.ts
+++ b/apps/vault/src/routes/editions/[id]/+page.server.ts
@@ -1,46 +1,95 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
-import { getMemberById } from '$lib/server/db/members';
+import { getMemberById, getAllMembers, type Member } from '$lib/server/db/members';
 import { getEditionById } from '$lib/server/db/editions';
 import { getWorkById } from '$lib/server/db/works';
 import { getAllSections } from '$lib/server/db/sections';
 import { canUploadScores } from '$lib/server/auth/permissions';
+import { getPhysicalCopiesByEdition } from '$lib/server/db/physical-copies';
+import { getActiveAssignments } from '$lib/server/db/copy-assignments';
+
+interface CopyWithAssignment {
+	id: string;
+	copyNumber: string;
+	condition: string;
+	assignment: {
+		memberId: string;
+		memberName: string;
+		assignedAt: string;
+	} | null;
+}
+
+async function loadCopiesWithAssignments(
+	db: D1Database,
+	editionId: string
+): Promise<CopyWithAssignment[]> {
+	const copies = await getPhysicalCopiesByEdition(db, editionId);
+	const members = await getAllMembers(db);
+	const memberMap = new Map(members.map((m) => [m.id, m.name]));
+
+	const copiesWithAssignments: CopyWithAssignment[] = [];
+
+	for (const copy of copies) {
+		const activeAssignments = await getActiveAssignments(db, copy.id);
+		const assignment = activeAssignments[0]; // Should only be one active
+
+		copiesWithAssignments.push({
+			id: copy.id,
+			copyNumber: copy.copyNumber,
+			condition: copy.condition,
+			assignment: assignment
+				? {
+						memberId: assignment.memberId,
+						memberName: memberMap.get(assignment.memberId) ?? 'Unknown',
+						assignedAt: assignment.assignedAt
+					}
+				: null
+		});
+	}
+
+	return copiesWithAssignments;
+}
+
+async function checkCanManage(db: D1Database, memberId: string | undefined): Promise<boolean> {
+	if (!memberId) return false;
+	const member = await getMemberById(db, memberId);
+	return member ? canUploadScores(member) : false;
+}
+
+async function loadLibrarianData(db: D1Database, editionId: string, canManage: boolean) {
+	if (!canManage) {
+		return { copies: [] as CopyWithAssignment[], members: [] as { id: string; name: string }[] };
+	}
+	const [copies, members] = await Promise.all([
+		loadCopiesWithAssignments(db, editionId),
+		getAllMembers(db)
+	]);
+	return { copies, members: members.map((m) => ({ id: m.id, name: m.name })) };
+}
 
 export const load: PageServerLoad = async ({ params, platform, cookies }) => {
 	const db = platform?.env?.DB;
-	if (!db) {
-		throw error(500, 'Database not available');
-	}
+	if (!db) throw error(500, 'Database not available');
 
 	const edition = await getEditionById(db, params.id);
-	if (!edition) {
-		throw error(404, 'Edition not found');
-	}
+	if (!edition) throw error(404, 'Edition not found');
 
-	// Get the parent work
 	const work = await getWorkById(db, edition.workId);
-	if (!work) {
-		throw error(404, 'Work not found');
-	}
+	if (!work) throw error(404, 'Work not found');
 
-	// Get sections for displaying linked sections
-	const sections = await getAllSections(db);
+	const canManage = await checkCanManage(db, cookies.get('member_id'));
 
-	// Get current user's permissions
-	let canManage = false;
-	const memberId = cookies.get('member_id');
-
-	if (memberId) {
-		const member = await getMemberById(db, memberId);
-		if (member) {
-			canManage = canUploadScores(member);
-		}
-	}
+	const [sections, librarianData] = await Promise.all([
+		getAllSections(db),
+		loadLibrarianData(db, params.id, canManage)
+	]);
 
 	return {
 		edition,
 		work,
 		sections,
-		canManage
+		canManage,
+		copies: librarianData.copies,
+		members: librarianData.members
 	};
 };


### PR DESCRIPTION
## Summary
Adds a 'Physical Copies' section to the Edition detail page for librarians to manage physical score inventory.

## Features
- **Copy count summary**: Shows total, assigned, and available copies
- **Batch create form**: Add multiple copies with optional prefix (e.g., 'M' → M-01, M-02, ...)
- **Copies table**: View all copies with condition and assignment status
- **Assign action**: Modal to assign available copy to a member
- **Return action**: Mark assigned copy as returned
- **Delete action**: Remove unassigned copies

## UI Preview
The section appears below 'Digital Assets' and is only visible to librarians (users with `scores:upload` permission).

## Acceptance Criteria (from #133)
- [x] Librarian can view list of physical copies for an edition
- [x] Librarian can batch-create copies (count + prefix)
- [x] Librarian can create single copy with custom number
- [x] Librarian can assign available copy to a member
- [x] Librarian can mark assigned copy as returned
- [x] Librarian can delete unassigned copies
- [x] Copy status shown clearly (available vs assigned to whom)
- [x] Empty state when no copies exist

## Testing
- All 475 vault tests pass
- TypeScript + ESLint pass (0 errors, 1 Svelte warning about initial state capture - handled with $effect)

Closes #133
Part of Epic #106 - Score Library Phase B