### PR TITLE
feat(seasons): add seasons CRUD with derived event membership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ wrangler d1 migrations apply DB
 | Framework       | SvelteKit 2 + Svelte 5     | Use Runes ($state, $derived, $effect) not legacy $ syntax |
 | Platform        | Cloudflare Pages + Workers | Edge deployment                                           |
 | Database        | Cloudflare D1 (SQLite)     | Per-deployment, local dev with wrangler                   |
-| File Storage    | D1 BLOBs (chunked)         | NO R2 - files in edition_files/edition_chunks tables     |
+| File Storage    | D1 BLOBs (chunked)         | NO R2 - files in edition_files/edition_chunks tables      |
 | Auth            | EdDSA (Ed25519) JWTs       | Registry signs, Vaults verify via JWKS                    |
 | Testing         | Vitest + Playwright        | Unit + E2E                                                |
 | Package Manager | pnpm (workspaces)          | Use workspace:\* for internal deps                        |

--- a/apps/vault/migrations/0022_seasons.sql
+++ b/apps/vault/migrations/0022_seasons.sql
@@ -1,0 +1,17 @@
+-- Seasons table for date-based event grouping
+-- Events belong to seasons by date range, not explicit FK
+-- Issue #119
+
+CREATE TABLE seasons (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    start_date TEXT NOT NULL UNIQUE,  -- YYYY-MM-DD, unique prevents overlap
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Index for efficient date lookups
+CREATE INDEX idx_seasons_start_date ON seasons(start_date);
+
+-- To find which season an event belongs to:
+-- SELECT * FROM seasons WHERE start_date <= :event_date ORDER BY start_date DESC LIMIT 1

--- a/apps/vault/src/lib/server/db/seasons.spec.ts
+++ b/apps/vault/src/lib/server/db/seasons.spec.ts
@@ -1,0 +1,305 @@
+// Seasons database layer tests
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	createSeason,
+	getSeason,
+	getAllSeasons,
+	getSeasonByDate,
+	getSeasonEvents,
+	updateSeason,
+	deleteSeason
+} from './seasons';
+
+// Mock D1Database
+function createMockDb() {
+	const mockRun = vi.fn().mockResolvedValue({ meta: { changes: 1 } });
+	const mockFirst = vi.fn();
+	const mockAll = vi.fn().mockResolvedValue({ results: [] });
+	const mockBind = vi.fn().mockReturnThis();
+
+	return {
+		prepare: vi.fn().mockReturnValue({
+			bind: mockBind,
+			run: mockRun,
+			first: mockFirst,
+			all: mockAll
+		}),
+		_mocks: { mockRun, mockFirst, mockAll, mockBind }
+	} as unknown as D1Database & { _mocks: typeof import('vitest') };
+}
+
+describe('Seasons database layer', () => {
+	let db: ReturnType<typeof createMockDb>;
+
+	beforeEach(() => {
+		db = createMockDb();
+	});
+
+	describe('createSeason', () => {
+		it('creates a season with name and start_date', async () => {
+			const season = await createSeason(db, {
+				name: 'Fall 2026',
+				start_date: '2026-09-01'
+			});
+
+			expect(season.name).toBe('Fall 2026');
+			expect(season.start_date).toBe('2026-09-01');
+			expect(season.id).toBeDefined();
+			expect(season.created_at).toBeDefined();
+			expect(season.updated_at).toBeDefined();
+		});
+
+		it('generates unique IDs', async () => {
+			const season1 = await createSeason(db, {
+				name: 'Fall 2026',
+				start_date: '2026-09-01'
+			});
+			const season2 = await createSeason(db, {
+				name: 'Spring 2027',
+				start_date: '2027-01-15'
+			});
+
+			expect(season1.id).not.toBe(season2.id);
+		});
+
+		it('throws error on duplicate start_date', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+				new Error('UNIQUE constraint failed: seasons.start_date')
+			);
+
+			await expect(
+				createSeason(db, { name: 'Duplicate', start_date: '2026-09-01' })
+			).rejects.toThrow('Season with start date 2026-09-01 already exists');
+		});
+	});
+
+	describe('getSeason', () => {
+		it('returns season when found', async () => {
+			const mockRow = {
+				id: 'season-123',
+				name: 'Fall 2026',
+				start_date: '2026-09-01',
+				created_at: '2026-01-30T12:00:00Z',
+				updated_at: '2026-01-30T12:00:00Z'
+			};
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockRow);
+
+			const season = await getSeason(db, 'season-123');
+
+			expect(season).toEqual(mockRow);
+		});
+
+		it('returns null when not found', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+			const season = await getSeason(db, 'nonexistent');
+
+			expect(season).toBeNull();
+		});
+	});
+
+	describe('getAllSeasons', () => {
+		it('returns all seasons ordered by start_date DESC', async () => {
+			const mockSeasons = [
+				{ id: 's2', name: 'Spring 2027', start_date: '2027-01-15', created_at: '', updated_at: '' },
+				{ id: 's1', name: 'Fall 2026', start_date: '2026-09-01', created_at: '', updated_at: '' }
+			];
+			(db.prepare('').all as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				results: mockSeasons
+			});
+
+			const seasons = await getAllSeasons(db);
+
+			expect(seasons).toHaveLength(2);
+			expect(seasons[0].name).toBe('Spring 2027');
+			expect(seasons[1].name).toBe('Fall 2026');
+		});
+
+		it('returns empty array when no seasons', async () => {
+			(db.prepare('').all as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ results: [] });
+
+			const seasons = await getAllSeasons(db);
+
+			expect(seasons).toEqual([]);
+		});
+	});
+
+	describe('getSeasonByDate', () => {
+		it('returns the season containing the date', async () => {
+			const mockSeason = {
+				id: 's1',
+				name: 'Fall 2026',
+				start_date: '2026-09-01',
+				created_at: '',
+				updated_at: ''
+			};
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockSeason);
+
+			const season = await getSeasonByDate(db, '2026-10-15');
+
+			expect(season).toEqual(mockSeason);
+			// Verify query uses ORDER BY start_date DESC LIMIT 1
+			expect(db.prepare).toHaveBeenCalledWith(
+				expect.stringContaining('ORDER BY start_date DESC LIMIT 1')
+			);
+		});
+
+		it('returns null when date is before all seasons', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+			const season = await getSeasonByDate(db, '2020-01-01');
+
+			expect(season).toBeNull();
+		});
+	});
+
+	describe('getSeasonEvents', () => {
+		it('returns empty array when season not found', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+			const events = await getSeasonEvents(db, 'nonexistent');
+
+			expect(events).toEqual([]);
+		});
+
+		it('queries events in date range when next season exists', async () => {
+			const mockSeason = {
+				id: 's1',
+				name: 'Fall 2026',
+				start_date: '2026-09-01',
+				created_at: '',
+				updated_at: ''
+			};
+			const mockNextSeason = { start_date: '2027-01-15' };
+			const mockEvents = [
+				{ id: 'e1', title: 'Concert 1', starts_at: '2026-10-01T19:00:00Z' },
+				{ id: 'e2', title: 'Concert 2', starts_at: '2026-12-20T19:00:00Z' }
+			];
+
+			// First call: getSeason
+			(db.prepare('').first as ReturnType<typeof vi.fn>)
+				.mockResolvedValueOnce(mockSeason)
+				// Second call: find next season
+				.mockResolvedValueOnce(mockNextSeason);
+			// Third call: get events
+			(db.prepare('').all as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				results: mockEvents
+			});
+
+			const events = await getSeasonEvents(db, 's1');
+
+			expect(events).toHaveLength(2);
+		});
+
+		it('queries events without upper bound for most recent season', async () => {
+			const mockSeason = {
+				id: 's1',
+				name: 'Spring 2027',
+				start_date: '2027-01-15',
+				created_at: '',
+				updated_at: ''
+			};
+			const mockEvents = [{ id: 'e1', title: 'Concert', starts_at: '2027-03-01T19:00:00Z' }];
+
+			// First call: getSeason
+			(db.prepare('').first as ReturnType<typeof vi.fn>)
+				.mockResolvedValueOnce(mockSeason)
+				// Second call: no next season
+				.mockResolvedValueOnce(null);
+			// Third call: get events (unbounded)
+			(db.prepare('').all as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				results: mockEvents
+			});
+
+			const events = await getSeasonEvents(db, 's1');
+
+			expect(events).toHaveLength(1);
+		});
+	});
+
+	describe('updateSeason', () => {
+		it('returns null when season not found', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+			const result = await updateSeason(db, 'nonexistent', { name: 'New Name' });
+
+			expect(result).toBeNull();
+		});
+
+		it('updates name only', async () => {
+			const existingSeason = {
+				id: 's1',
+				name: 'Fall 2026',
+				start_date: '2026-09-01',
+				created_at: '2026-01-30T12:00:00Z',
+				updated_at: '2026-01-30T12:00:00Z'
+			};
+			const updatedSeason = { ...existingSeason, name: 'Autumn 2026' };
+
+			(db.prepare('').first as ReturnType<typeof vi.fn>)
+				.mockResolvedValueOnce(existingSeason)
+				.mockResolvedValueOnce(updatedSeason);
+
+			const result = await updateSeason(db, 's1', { name: 'Autumn 2026' });
+
+			expect(result?.name).toBe('Autumn 2026');
+		});
+
+		it('returns existing season when no updates provided', async () => {
+			const existingSeason = {
+				id: 's1',
+				name: 'Fall 2026',
+				start_date: '2026-09-01',
+				created_at: '',
+				updated_at: ''
+			};
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(existingSeason);
+
+			const result = await updateSeason(db, 's1', {});
+
+			expect(result).toEqual(existingSeason);
+			// run() should not be called since no updates
+			expect(db.prepare('').run).not.toHaveBeenCalled();
+		});
+
+		it('throws error on duplicate start_date', async () => {
+			const existingSeason = {
+				id: 's1',
+				name: 'Fall 2026',
+				start_date: '2026-09-01',
+				created_at: '',
+				updated_at: ''
+			};
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(existingSeason);
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+				new Error('UNIQUE constraint failed: seasons.start_date')
+			);
+
+			await expect(
+				updateSeason(db, 's1', { start_date: '2027-01-15' })
+			).rejects.toThrow('Season with start date 2027-01-15 already exists');
+		});
+	});
+
+	describe('deleteSeason', () => {
+		it('returns true when season deleted', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				meta: { changes: 1 }
+			});
+
+			const result = await deleteSeason(db, 's1');
+
+			expect(result).toBe(true);
+		});
+
+		it('returns false when season not found', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				meta: { changes: 0 }
+			});
+
+			const result = await deleteSeason(db, 'nonexistent');
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/apps/vault/src/lib/server/db/seasons.ts
+++ b/apps/vault/src/lib/server/db/seasons.ts
@@ -1,0 +1,218 @@
+// Seasons database operations
+// Seasons define date-based groupings for events
+// Events belong to seasons by date, not explicit FK
+
+import { nanoid } from 'nanoid';
+import type { Event } from './events';
+
+export interface Season {
+	id: string;
+	name: string;
+	start_date: string; // YYYY-MM-DD
+	created_at: string;
+	updated_at: string;
+}
+
+export interface CreateSeasonInput {
+	name: string;
+	start_date: string; // YYYY-MM-DD
+}
+
+export interface UpdateSeasonInput {
+	name?: string;
+	start_date?: string;
+}
+
+/**
+ * Create a new season
+ * @throws Error if start_date already exists (UNIQUE constraint)
+ */
+export async function createSeason(
+	db: D1Database,
+	input: CreateSeasonInput
+): Promise<Season> {
+	const id = nanoid();
+	const now = new Date().toISOString();
+
+	try {
+		await db
+			.prepare(
+				'INSERT INTO seasons (id, name, start_date, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
+			)
+			.bind(id, input.name, input.start_date, now, now)
+			.run();
+	} catch (error) {
+		// Check for UNIQUE constraint violation on start_date
+		if (error instanceof Error && error.message.includes('UNIQUE')) {
+			throw new Error(`Season with start date ${input.start_date} already exists`);
+		}
+		throw error;
+	}
+
+	return {
+		id,
+		name: input.name,
+		start_date: input.start_date,
+		created_at: now,
+		updated_at: now
+	};
+}
+
+/**
+ * Get a season by ID
+ */
+export async function getSeason(
+	db: D1Database,
+	id: string
+): Promise<Season | null> {
+	return await db
+		.prepare('SELECT id, name, start_date, created_at, updated_at FROM seasons WHERE id = ?')
+		.bind(id)
+		.first<Season>();
+}
+
+/**
+ * Get all seasons ordered by start_date DESC (most recent first)
+ */
+export async function getAllSeasons(db: D1Database): Promise<Season[]> {
+	const result = await db
+		.prepare('SELECT id, name, start_date, created_at, updated_at FROM seasons ORDER BY start_date DESC')
+		.all<Season>();
+
+	return result.results;
+}
+
+/**
+ * Find which season a given date falls into
+ * A date belongs to the season with the largest start_date <= the given date
+ */
+export async function getSeasonByDate(
+	db: D1Database,
+	date: string // YYYY-MM-DD
+): Promise<Season | null> {
+	return await db
+		.prepare(
+			'SELECT id, name, start_date, created_at, updated_at FROM seasons WHERE start_date <= ? ORDER BY start_date DESC LIMIT 1'
+		)
+		.bind(date)
+		.first<Season>();
+}
+
+/**
+ * Get all events within a season's date range
+ * A season's range is from its start_date to the day before the next season's start_date
+ * (or unbounded if it's the most recent season)
+ */
+export async function getSeasonEvents(
+	db: D1Database,
+	seasonId: string
+): Promise<Event[]> {
+	// First get the season
+	const season = await getSeason(db, seasonId);
+	if (!season) {
+		return [];
+	}
+
+	// Find the next season's start date (if any)
+	const nextSeason = await db
+		.prepare(
+			'SELECT start_date FROM seasons WHERE start_date > ? ORDER BY start_date ASC LIMIT 1'
+		)
+		.bind(season.start_date)
+		.first<{ start_date: string }>();
+
+	// Build query based on whether there's a next season
+	if (nextSeason) {
+		// Events from this season's start to before next season's start
+		const result = await db
+			.prepare(
+				`SELECT id, title, description, location, starts_at, ends_at, event_type, created_by, created_at 
+				 FROM events 
+				 WHERE DATE(starts_at) >= ? AND DATE(starts_at) < ?
+				 ORDER BY starts_at ASC`
+			)
+			.bind(season.start_date, nextSeason.start_date)
+			.all<Event>();
+
+		return result.results;
+	} else {
+		// This is the most recent season - all events from start_date onwards
+		const result = await db
+			.prepare(
+				`SELECT id, title, description, location, starts_at, ends_at, event_type, created_by, created_at 
+				 FROM events 
+				 WHERE DATE(starts_at) >= ?
+				 ORDER BY starts_at ASC`
+			)
+			.bind(season.start_date)
+			.all<Event>();
+
+		return result.results;
+	}
+}
+
+/**
+ * Update a season
+ * @throws Error if start_date already exists on another season
+ */
+export async function updateSeason(
+	db: D1Database,
+	id: string,
+	input: UpdateSeasonInput
+): Promise<Season | null> {
+	const existing = await getSeason(db, id);
+	if (!existing) {
+		return null;
+	}
+
+	const updates: string[] = [];
+	const values: (string | null)[] = [];
+
+	if (input.name !== undefined) {
+		updates.push('name = ?');
+		values.push(input.name);
+	}
+
+	if (input.start_date !== undefined) {
+		updates.push('start_date = ?');
+		values.push(input.start_date);
+	}
+
+	if (updates.length === 0) {
+		return existing;
+	}
+
+	updates.push('updated_at = ?');
+	values.push(new Date().toISOString());
+	values.push(id);
+
+	try {
+		await db
+			.prepare(`UPDATE seasons SET ${updates.join(', ')} WHERE id = ?`)
+			.bind(...values)
+			.run();
+	} catch (error) {
+		if (error instanceof Error && error.message.includes('UNIQUE')) {
+			throw new Error(`Season with start date ${input.start_date} already exists`);
+		}
+		throw error;
+	}
+
+	return await getSeason(db, id);
+}
+
+/**
+ * Delete a season
+ * @returns true if deleted, false if not found
+ */
+export async function deleteSeason(
+	db: D1Database,
+	id: string
+): Promise<boolean> {
+	const result = await db
+		.prepare('DELETE FROM seasons WHERE id = ?')
+		.bind(id)
+		.run();
+
+	return (result.meta.changes ?? 0) > 0;
+}

--- a/apps/vault/src/routes/api/seasons/+server.ts
+++ b/apps/vault/src/routes/api/seasons/+server.ts
@@ -1,0 +1,70 @@
+// API endpoint for seasons collection operations
+// GET /api/seasons - List all seasons
+// POST /api/seasons - Create a new season
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { getAuthenticatedMember, assertAdmin } from '$lib/server/auth/middleware';
+import { createSeason, getAllSeasons, getSeasonByDate } from '$lib/server/db/seasons';
+
+export async function GET({ url, platform, cookies }: RequestEvent) {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	// Auth: any authenticated member can view seasons
+	await getAuthenticatedMember(db, cookies);
+
+	// Check for date query parameter
+	const dateParam = url.searchParams.get('date');
+	
+	if (dateParam) {
+		// Find which season contains this date
+		const season = await getSeasonByDate(db, dateParam);
+		return json(season);
+	}
+
+	const seasons = await getAllSeasons(db);
+	return json(seasons);
+}
+
+export async function POST({ request, platform, cookies }: RequestEvent) {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	// Auth: require admin role to create seasons
+	const member = await getAuthenticatedMember(db, cookies);
+	assertAdmin(member);
+
+	// Parse request body
+	const body = (await request.json()) as { name?: string; start_date?: string };
+
+	// Validate required fields
+	if (!body.name || typeof body.name !== 'string' || body.name.trim().length === 0) {
+		return json({ error: 'Name is required' }, { status: 400 });
+	}
+
+	if (!body.start_date || typeof body.start_date !== 'string') {
+		return json({ error: 'Start date is required' }, { status: 400 });
+	}
+
+	// Validate date format (YYYY-MM-DD)
+	const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+	if (!dateRegex.test(body.start_date)) {
+		return json({ error: 'Start date must be in YYYY-MM-DD format' }, { status: 400 });
+	}
+
+	try {
+		const season = await createSeason(db, {
+			name: body.name.trim(),
+			start_date: body.start_date
+		});
+		return json(season, { status: 201 });
+	} catch (err) {
+		if (err instanceof Error && err.message.includes('already exists')) {
+			return json({ error: err.message }, { status: 409 });
+		}
+		throw err;
+	}
+}

--- a/apps/vault/src/routes/api/seasons/[id]/+server.ts
+++ b/apps/vault/src/routes/api/seasons/[id]/+server.ts
@@ -1,0 +1,114 @@
+// API endpoint for individual season operations
+// GET /api/seasons/[id] - Get a season by ID (with optional events)
+// PATCH /api/seasons/[id] - Update a season
+// DELETE /api/seasons/[id] - Delete a season
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { getAuthenticatedMember, assertAdmin } from '$lib/server/auth/middleware';
+import { getSeason, getSeasonEvents, updateSeason, deleteSeason } from '$lib/server/db/seasons';
+
+export async function GET({ params, url, platform, cookies }: RequestEvent) {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	// Auth: any authenticated member can view seasons
+	await getAuthenticatedMember(db, cookies);
+
+	const seasonId = params.id;
+	if (!seasonId) {
+		throw error(400, 'Season ID is required');
+	}
+
+	const season = await getSeason(db, seasonId);
+	if (!season) {
+		throw error(404, 'Season not found');
+	}
+
+	// Check if events should be included
+	const includeEvents = url.searchParams.get('events') === 'true';
+	
+	if (includeEvents) {
+		const events = await getSeasonEvents(db, seasonId);
+		return json({ ...season, events });
+	}
+
+	return json(season);
+}
+
+export async function PATCH({ params, request, platform, cookies }: RequestEvent) {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	// Auth: require admin role to update seasons
+	const member = await getAuthenticatedMember(db, cookies);
+	assertAdmin(member);
+
+	const seasonId = params.id;
+	if (!seasonId) {
+		throw error(400, 'Season ID is required');
+	}
+
+	// Parse request body
+	const body = (await request.json()) as { name?: string; start_date?: string };
+
+	// Build update input (only include provided fields)
+	const input: { name?: string; start_date?: string } = {};
+	
+	if (body.name !== undefined) {
+		if (typeof body.name !== 'string' || body.name.trim().length === 0) {
+			return json({ error: 'Name cannot be empty' }, { status: 400 });
+		}
+		input.name = body.name.trim();
+	}
+	
+	if (body.start_date !== undefined) {
+		if (typeof body.start_date !== 'string') {
+			return json({ error: 'Start date must be a string' }, { status: 400 });
+		}
+		// Validate date format (YYYY-MM-DD)
+		const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+		if (!dateRegex.test(body.start_date)) {
+			return json({ error: 'Start date must be in YYYY-MM-DD format' }, { status: 400 });
+		}
+		input.start_date = body.start_date;
+	}
+
+	try {
+		const updated = await updateSeason(db, seasonId, input);
+		if (!updated) {
+			throw error(404, 'Season not found');
+		}
+		return json(updated);
+	} catch (err) {
+		if (err instanceof Error && err.message.includes('already exists')) {
+			return json({ error: err.message }, { status: 409 });
+		}
+		throw err;
+	}
+}
+
+export async function DELETE({ params, platform, cookies }: RequestEvent) {
+	const db = platform?.env?.DB;
+	if (!db) {
+		throw error(500, 'Database not available');
+	}
+
+	// Auth: require admin role to delete seasons
+	const member = await getAuthenticatedMember(db, cookies);
+	assertAdmin(member);
+
+	const seasonId = params.id;
+	if (!seasonId) {
+		throw error(400, 'Season ID is required');
+	}
+
+	const deleted = await deleteSeason(db, seasonId);
+	if (!deleted) {
+		throw error(404, 'Season not found');
+	}
+
+	return json({ success: true });
+}

--- a/apps/vault/src/routes/seasons/+page.server.ts
+++ b/apps/vault/src/routes/seasons/+page.server.ts
@@ -1,0 +1,28 @@
+import type { PageServerLoad } from './$types';
+import { getMemberById } from '$lib/server/db/members';
+import { canManageEvents } from '$lib/server/auth/permissions';
+import type { Season } from '$lib/server/db/seasons';
+
+export const load: PageServerLoad = async ({ fetch, platform, cookies }) => {
+	const response = await fetch('/api/seasons');
+	const seasons = (await response.json()) as Season[];
+
+	// Get current user's permissions (admins can manage seasons)
+	let canManage = false;
+
+	const db = platform?.env?.DB;
+	const memberId = cookies.get('member_id');
+
+	if (db && memberId) {
+		const member = await getMemberById(db, memberId);
+		if (member) {
+			// Admins and owners can manage seasons
+			canManage = canManageEvents(member);
+		}
+	}
+
+	return {
+		seasons: seasons ?? [],
+		canManage
+	};
+};

--- a/apps/vault/src/routes/seasons/+page.svelte
+++ b/apps/vault/src/routes/seasons/+page.svelte
@@ -1,0 +1,327 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import type { PageData } from './$types';
+	import type { Season } from '$lib/server/db/seasons';
+	import Modal from '$lib/components/Modal.svelte';
+	import Card from '$lib/components/Card.svelte';
+
+	let { data }: { data: PageData } = $props();
+
+	// Local state
+	let seasons = $state<Season[]>(untrack(() => data.seasons));
+	let showCreateForm = $state(false);
+	let editingSeason = $state<Season | null>(null);
+	let deletingId = $state<string | null>(null);
+	let saving = $state(false);
+	let error = $state('');
+	let success = $state('');
+
+	// Form state
+	let formName = $state('');
+	let formStartDate = $state('');
+
+	// Sync with data on navigation
+	$effect(() => {
+		seasons = data.seasons;
+	});
+
+	function openCreateForm() {
+		formName = '';
+		formStartDate = '';
+		editingSeason = null;
+		showCreateForm = true;
+	}
+
+	function openEditForm(season: Season) {
+		formName = season.name;
+		formStartDate = season.start_date;
+		editingSeason = season;
+		showCreateForm = true;
+	}
+
+	function closeForm() {
+		showCreateForm = false;
+		editingSeason = null;
+		formName = '';
+		formStartDate = '';
+	}
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+
+		if (!formName.trim()) {
+			error = 'Name is required';
+			return;
+		}
+
+		if (!formStartDate) {
+			error = 'Start date is required';
+			return;
+		}
+
+		saving = true;
+		error = '';
+
+		try {
+			if (editingSeason) {
+				// Update existing season
+				const response = await fetch(`/api/seasons/${editingSeason.id}`, {
+					method: 'PATCH',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						name: formName.trim(),
+						start_date: formStartDate
+					})
+				});
+
+				if (!response.ok) {
+					const data = (await response.json()) as { error?: string };
+					throw new Error(data.error ?? 'Failed to update season');
+				}
+
+				const updated = (await response.json()) as Season;
+				seasons = seasons.map((s) => (s.id === updated.id ? updated : s));
+				// Re-sort by start_date DESC
+				seasons = [...seasons].sort(
+					(a, b) => new Date(b.start_date).getTime() - new Date(a.start_date).getTime()
+				);
+				success = `"${updated.name}" updated successfully`;
+			} else {
+				// Create new season
+				const response = await fetch('/api/seasons', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						name: formName.trim(),
+						start_date: formStartDate
+					})
+				});
+
+				if (!response.ok) {
+					const data = (await response.json()) as { error?: string };
+					throw new Error(data.error ?? 'Failed to create season');
+				}
+
+				const created = (await response.json()) as Season;
+				// Insert and re-sort by start_date DESC
+				seasons = [...seasons, created].sort(
+					(a, b) => new Date(b.start_date).getTime() - new Date(a.start_date).getTime()
+				);
+				success = `"${created.name}" created successfully`;
+			}
+
+			closeForm();
+			setTimeout(() => (success = ''), 3000);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Operation failed';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deleteSeason(season: Season) {
+		if (!confirm(`Delete "${season.name}"? This cannot be undone.`)) return;
+
+		deletingId = season.id;
+		error = '';
+
+		try {
+			const response = await fetch(`/api/seasons/${season.id}`, { method: 'DELETE' });
+
+			if (!response.ok) {
+				const data = (await response.json()) as { error?: string };
+				throw new Error(data.error ?? 'Failed to delete season');
+			}
+
+			seasons = seasons.filter((s) => s.id !== season.id);
+			success = `"${season.name}" deleted`;
+			setTimeout(() => (success = ''), 3000);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Delete failed';
+		} finally {
+			deletingId = null;
+		}
+	}
+
+	function formatDate(dateStr: string): string {
+		const date = new Date(dateStr + 'T00:00:00');
+		return date.toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric'
+		});
+	}
+
+	function getSeasonEndDate(season: Season, index: number): string | null {
+		// The end date is the day before the next season's start
+		// (or null if this is the most recent season)
+		if (index === 0) return null; // Most recent season has no end
+
+		const prevSeasonStart = seasons[index - 1].start_date;
+		const endDate = new Date(prevSeasonStart + 'T00:00:00');
+		endDate.setDate(endDate.getDate() - 1);
+		return endDate.toISOString().split('T')[0];
+	}
+</script>
+
+<svelte:head>
+	<title>Seasons | Polyphony Vault</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl px-4 py-8">
+	<div class="mb-8 flex items-center justify-between">
+		<div>
+			<h1 class="text-3xl font-bold">Seasons</h1>
+			<p class="mt-1 text-gray-600">Date-based groupings for your events</p>
+		</div>
+		{#if data.canManage}
+			<button
+				onclick={openCreateForm}
+				class="rounded-lg bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700"
+			>
+				+ Add Season
+			</button>
+		{/if}
+	</div>
+
+	{#if error}
+		<div class="mb-4 rounded-lg bg-red-100 p-4 text-red-700">
+			{error}
+			<button onclick={() => (error = '')} class="ml-2 text-red-900 hover:underline">×</button>
+		</div>
+	{/if}
+
+	{#if success}
+		<div class="mb-4 rounded-lg bg-green-100 p-4 text-green-700">
+			{success}
+		</div>
+	{/if}
+
+	<!-- Create/Edit Form Modal -->
+	<Modal
+		open={showCreateForm}
+		title={editingSeason ? 'Edit Season' : 'Add New Season'}
+		onclose={closeForm}
+	>
+		<form onsubmit={handleSubmit}>
+			<div class="mb-4">
+				<label for="name" class="mb-1 block text-sm font-medium text-gray-700">
+					Name <span class="text-red-500">*</span>
+				</label>
+				<input
+					id="name"
+					type="text"
+					bind:value={formName}
+					class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+					placeholder="e.g., Fall 2026"
+					required
+				/>
+			</div>
+			<div class="mb-4">
+				<label for="start_date" class="mb-1 block text-sm font-medium text-gray-700">
+					Start Date <span class="text-red-500">*</span>
+				</label>
+				<input
+					id="start_date"
+					type="date"
+					bind:value={formStartDate}
+					class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+					required
+				/>
+				<p class="mt-1 text-xs text-gray-500">
+					The season ends the day before the next season starts.
+				</p>
+			</div>
+
+			<div class="flex justify-end gap-3 pt-4">
+				<button
+					type="button"
+					onclick={closeForm}
+					class="rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-50"
+				>
+					Cancel
+				</button>
+				<button
+					type="submit"
+					disabled={saving}
+					class="rounded-lg bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700 disabled:opacity-50"
+				>
+					{saving ? 'Saving...' : editingSeason ? 'Update' : 'Create'}
+				</button>
+			</div>
+		</form>
+	</Modal>
+
+	<!-- Seasons List -->
+	{#if seasons.length === 0}
+		<Card padding="lg">
+			<div class="py-8 text-center text-gray-500">
+				<p>No seasons defined yet.</p>
+				{#if data.canManage}
+					<p class="mt-2">
+						<button onclick={openCreateForm} class="text-blue-600 hover:underline">
+							Add your first season
+						</button>
+					</p>
+				{/if}
+			</div>
+		</Card>
+	{:else}
+		<div class="space-y-4">
+			{#each seasons as season, index (season.id)}
+				{@const endDate = getSeasonEndDate(season, index)}
+				<Card variant={data.canManage ? 'interactive' : 'static'} padding="lg">
+					<div class="flex items-center justify-between">
+						<div class="flex-1">
+							<div class="flex items-center gap-3">
+								<h3 class="text-lg font-semibold">
+									<a
+										href="/seasons/{season.id}"
+										class="hover:text-blue-600 hover:underline"
+									>
+										{season.name}
+									</a>
+								</h3>
+								{#if index === 0}
+									<span class="rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800">
+										Current
+									</span>
+								{/if}
+							</div>
+							<p class="mt-1 text-sm text-gray-600">
+								{formatDate(season.start_date)}
+								{#if endDate}
+									<span class="text-gray-400">→</span>
+									{formatDate(endDate)}
+								{:else}
+									<span class="text-gray-400">→ ongoing</span>
+								{/if}
+							</p>
+						</div>
+						{#if data.canManage}
+							<div class="flex items-center gap-2">
+								<button
+									onclick={() => openEditForm(season)}
+									class="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50"
+								>
+									Edit
+								</button>
+								<button
+									onclick={() => deleteSeason(season)}
+									disabled={deletingId === season.id}
+									class="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+								>
+									{deletingId === season.id ? 'Deleting...' : 'Delete'}
+								</button>
+							</div>
+						{/if}
+					</div>
+				</Card>
+			{/each}
+		</div>
+
+		<p class="mt-6 text-sm text-gray-500">
+			{seasons.length} season{seasons.length === 1 ? '' : 's'}
+		</p>
+	{/if}
+</div>

--- a/apps/vault/src/routes/seasons/[id]/+page.server.ts
+++ b/apps/vault/src/routes/seasons/[id]/+page.server.ts
@@ -1,0 +1,48 @@
+import type { PageServerLoad } from './$types';
+import { error } from '@sveltejs/kit';
+import { getMemberById } from '$lib/server/db/members';
+import { canManageEvents } from '$lib/server/auth/permissions';
+import type { Season } from '$lib/server/db/seasons';
+import type { Event } from '$lib/server/db/events';
+
+interface SeasonWithEvents extends Season {
+	events: Event[];
+}
+
+export const load: PageServerLoad = async ({ params, fetch, platform, cookies }) => {
+	const seasonId = params.id;
+	if (!seasonId) {
+		throw error(400, 'Season ID is required');
+	}
+
+	// Fetch season with events
+	const response = await fetch(`/api/seasons/${seasonId}?events=true`);
+	
+	if (!response.ok) {
+		if (response.status === 404) {
+			throw error(404, 'Season not found');
+		}
+		throw error(response.status, 'Failed to load season');
+	}
+
+	const season = (await response.json()) as SeasonWithEvents;
+
+	// Get current user's permissions
+	let canManage = false;
+
+	const db = platform?.env?.DB;
+	const memberId = cookies.get('member_id');
+
+	if (db && memberId) {
+		const member = await getMemberById(db, memberId);
+		if (member) {
+			canManage = canManageEvents(member);
+		}
+	}
+
+	return {
+		season,
+		events: season.events ?? [],
+		canManage
+	};
+};

--- a/apps/vault/src/routes/seasons/[id]/+page.svelte
+++ b/apps/vault/src/routes/seasons/[id]/+page.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import Card from '$lib/components/Card.svelte';
+
+	let { data }: { data: PageData } = $props();
+
+	function formatDateTime(isoString: string): string {
+		const date = new Date(isoString);
+		return date.toLocaleDateString('en-US', {
+			weekday: 'short',
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit'
+		});
+	}
+
+	function getEventTypeBadge(eventType: string): { bg: string; text: string } {
+		switch (eventType) {
+			case 'concert':
+				return { bg: 'bg-purple-100', text: 'text-purple-800' };
+			case 'rehearsal':
+				return { bg: 'bg-blue-100', text: 'text-blue-800' };
+			case 'retreat':
+				return { bg: 'bg-green-100', text: 'text-green-800' };
+			default:
+				return { bg: 'bg-gray-100', text: 'text-gray-800' };
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{data.season.name} | Polyphony Vault</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl px-4 py-8">
+	<!-- Back link -->
+	<div class="mb-4">
+		<a href="/seasons" class="text-blue-600 hover:underline">← All Seasons</a>
+	</div>
+
+	<div class="mb-8">
+		<h1 class="text-3xl font-bold">{data.season.name}</h1>
+		<p class="mt-1 text-gray-600">
+			Starts {new Date(data.season.start_date + 'T00:00:00').toLocaleDateString('en-US', {
+				year: 'numeric',
+				month: 'long',
+				day: 'numeric'
+			})}
+		</p>
+	</div>
+
+	<!-- Events in this season -->
+	<section>
+		<div class="mb-4 flex items-center justify-between">
+			<h2 class="text-xl font-semibold">Events in this Season</h2>
+			{#if data.canManage}
+				<a
+					href="/events/new?season={data.season.id}"
+					class="rounded-lg bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700"
+				>
+					+ Add Event
+				</a>
+			{/if}
+		</div>
+
+		{#if data.events.length === 0}
+			<Card padding="lg">
+				<div class="py-8 text-center text-gray-500">
+					<p>No events in this season yet.</p>
+					{#if data.canManage}
+						<p class="mt-2">
+							<a href="/events/new" class="text-blue-600 hover:underline">
+								Create an event
+							</a>
+						</p>
+					{/if}
+				</div>
+			</Card>
+		{:else}
+			<div class="space-y-3">
+				{#each data.events as event (event.id)}
+					{@const badge = getEventTypeBadge(event.event_type)}
+					<Card variant="clickable" padding="md" href="/events/{event.id}">
+						<div class="flex items-center justify-between">
+							<div>
+								<div class="flex items-center gap-2">
+									<h3 class="font-medium">{event.title}</h3>
+									<span class="{badge.bg} {badge.text} rounded px-2 py-0.5 text-xs font-medium">
+										{event.event_type}
+									</span>
+								</div>
+								<p class="mt-1 text-sm text-gray-600">
+									{formatDateTime(event.starts_at)}
+									{#if event.location}
+										<span class="text-gray-400">•</span>
+										{event.location}
+									{/if}
+								</p>
+							</div>
+						</div>
+					</Card>
+				{/each}
+			</div>
+
+			<p class="mt-6 text-sm text-gray-500">
+				{data.events.length} event{data.events.length === 1 ? '' : 's'} in this season
+			</p>
+		{/if}
+	</section>
+</div>

--- a/docs/DATABASE-SCHEMA.md
+++ b/docs/DATABASE-SCHEMA.md
@@ -579,13 +579,13 @@ Rehearsals, concerts, and other choir events.
 
 Setlists linking editions to events in order.
 
-| Column     | Type    | Constraints                            | Description                |
-| ---------- | ------- | -------------------------------------- | -------------------------- |
-| event_id   | TEXT    | PK, FK → events(id) ON DELETE CASCADE  | Event reference            |
-| edition_id | TEXT    | PK, FK → editions(id) ON DELETE CASCADE | Edition reference         |
-| position   | INTEGER | NOT NULL, DEFAULT 0                    | Order in program (0-based) |
-| notes      | TEXT    |                                        | Notes about this piece     |
-| added_at   | TEXT    | DEFAULT now()                          | When added to program      |
+| Column     | Type    | Constraints                             | Description                |
+| ---------- | ------- | --------------------------------------- | -------------------------- |
+| event_id   | TEXT    | PK, FK → events(id) ON DELETE CASCADE   | Event reference            |
+| edition_id | TEXT    | PK, FK → editions(id) ON DELETE CASCADE | Edition reference          |
+| position   | INTEGER | NOT NULL, DEFAULT 0                     | Order in program (0-based) |
+| notes      | TEXT    |                                         | Notes about this piece     |
+| added_at   | TEXT    | DEFAULT now()                           | When added to program      |
 
 **Indexes:**
 


### PR DESCRIPTION
## Summary

Implements Seasons CRUD with date-based event membership (#119).

## Changes

### Database
- **Migration 0022**: Creates `seasons` table with:
  - `id`, `name`, `start_date` (UNIQUE), `created_at`, `updated_at`
  - Index on `start_date` for efficient lookups

### Server
- **`src/lib/server/db/seasons.ts`**: Full CRUD operations:
  - `createSeason()`, `getSeason()`, `getAllSeasons()`
  - `getSeasonByDate(date)` - find which season contains a date
  - `getSeasonEvents(seasonId)` - get all events in a season's date range
  - `updateSeason()`, `deleteSeason()`
  
- **18 unit tests** for all DB operations

### API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/seasons` | List all seasons |
| GET | `/api/seasons?date=YYYY-MM-DD` | Find season by date |
| POST | `/api/seasons` | Create season (admin) |
| GET | `/api/seasons/[id]` | Get season |
| GET | `/api/seasons/[id]?events=true` | Get season with events |
| PATCH | `/api/seasons/[id]` | Update season (admin) |
| DELETE | `/api/seasons/[id]` | Delete season (admin) |

### UI Pages
- **`/seasons`** - List all seasons with create/edit/delete
- **`/seasons/[id]`** - Season detail showing events in that season

## Design Notes

Seasons only have `start_date` (UNIQUE). The next season's start_date implicitly defines the end of the previous season. Events belong to seasons by their `starts_at` date falling within the range, not by explicit FK.

```sql
-- Find event's season
SELECT * FROM seasons WHERE start_date <= :event_date ORDER BY start_date DESC LIMIT 1
```

## Testing

- ✅ 18 new unit tests for seasons DB layer
- ✅ All 545 tests passing (20 shared + 62 registry + 463 vault)
- ✅ Type check clean

Closes #119