### PR TITLE
feat(vault): add season repertoire management

### DIFF
--- a/apps/vault/migrations/0023_season_repertoire.sql
+++ b/apps/vault/migrations/0023_season_repertoire.sql
@@ -1,0 +1,40 @@
+-- Season repertoire: works and editions for each season
+-- Two-stage: select Works (ordered), then Editions per work
+-- Issue #120
+
+-- Works assigned to a season with display order
+CREATE TABLE season_works (
+    id TEXT PRIMARY KEY,
+    season_id TEXT NOT NULL REFERENCES seasons(id) ON DELETE CASCADE,
+    work_id TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    display_order INTEGER NOT NULL DEFAULT 0,
+    notes TEXT,
+    added_at TEXT NOT NULL DEFAULT (datetime('now')),
+    added_by TEXT REFERENCES members(id) ON DELETE SET NULL,
+    
+    -- Same work can't be added twice to same season
+    UNIQUE(season_id, work_id)
+);
+
+-- Index for efficient season lookups
+CREATE INDEX idx_season_works_season ON season_works(season_id, display_order);
+CREATE INDEX idx_season_works_work ON season_works(work_id);
+
+-- Editions selected for each season-work pairing
+-- Multiple editions can be selected per work (e.g., vocal score + orchestral parts)
+CREATE TABLE season_work_editions (
+    id TEXT PRIMARY KEY,
+    season_work_id TEXT NOT NULL REFERENCES season_works(id) ON DELETE CASCADE,
+    edition_id TEXT NOT NULL REFERENCES editions(id) ON DELETE CASCADE,
+    is_primary INTEGER NOT NULL DEFAULT 0,  -- Mark the main edition
+    notes TEXT,
+    added_at TEXT NOT NULL DEFAULT (datetime('now')),
+    added_by TEXT REFERENCES members(id) ON DELETE SET NULL,
+    
+    -- Same edition can't be added twice to same season-work
+    UNIQUE(season_work_id, edition_id)
+);
+
+-- Index for efficient lookups
+CREATE INDEX idx_season_work_editions_sw ON season_work_editions(season_work_id);
+CREATE INDEX idx_season_work_editions_edition ON season_work_editions(edition_id);

--- a/apps/vault/src/lib/server/db/season-repertoire.spec.ts
+++ b/apps/vault/src/lib/server/db/season-repertoire.spec.ts
@@ -1,0 +1,346 @@
+// Season repertoire database layer tests
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	addWorkToSeason,
+	removeWorkFromSeason,
+	reorderSeasonWorks,
+	updateSeasonWorkNotes,
+	addEditionToSeasonWork,
+	removeEditionFromSeasonWork,
+	setPrimaryEdition,
+	getSeasonRepertoire,
+	getSeasonWork,
+	isWorkInSeason
+} from './season-repertoire';
+
+// Mock D1Database
+function createMockDb() {
+	const mockRun = vi.fn().mockResolvedValue({ meta: { changes: 1 } });
+	const mockFirst = vi.fn();
+	const mockAll = vi.fn().mockResolvedValue({ results: [] });
+	const mockBind = vi.fn().mockReturnThis();
+	const mockBatch = vi.fn().mockResolvedValue([]);
+
+	return {
+		prepare: vi.fn().mockReturnValue({
+			bind: mockBind,
+			run: mockRun,
+			first: mockFirst,
+			all: mockAll
+		}),
+		batch: mockBatch,
+		_mocks: { mockRun, mockFirst, mockAll, mockBind, mockBatch }
+	} as unknown as D1Database & { _mocks: typeof import('vitest'); batch: typeof mockBatch };
+}
+
+describe('Season Repertoire - Works', () => {
+	let db: ReturnType<typeof createMockDb>;
+
+	beforeEach(() => {
+		db = createMockDb();
+	});
+
+	describe('addWorkToSeason', () => {
+		it('adds a work with auto-incremented display order', async () => {
+			// Mock: get max display_order returns 2
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ max: 2 });
+
+			const result = await addWorkToSeason(db, 'season-1', 'work-1', 'member-1');
+
+			expect(result.season_id).toBe('season-1');
+			expect(result.work_id).toBe('work-1');
+			expect(result.display_order).toBe(3); // max + 1
+			expect(result.added_by).toBe('member-1');
+			expect(result.id).toBeDefined();
+		});
+
+		it('starts at 0 when no works exist', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ max: null });
+
+			const result = await addWorkToSeason(db, 'season-1', 'work-1');
+
+			expect(result.display_order).toBe(0);
+		});
+
+		it('throws error on duplicate work in season', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ max: 0 });
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+				new Error('UNIQUE constraint failed: season_works.season_id, season_works.work_id')
+			);
+
+			await expect(
+				addWorkToSeason(db, 'season-1', 'work-1')
+			).rejects.toThrow('Work is already in this season\'s repertoire');
+		});
+	});
+
+	describe('removeWorkFromSeason', () => {
+		it('returns true when work removed', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				meta: { changes: 1 }
+			});
+
+			const result = await removeWorkFromSeason(db, 'sw-1');
+
+			expect(result).toBe(true);
+		});
+
+		it('returns false when work not found', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				meta: { changes: 0 }
+			});
+
+			const result = await removeWorkFromSeason(db, 'nonexistent');
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('reorderSeasonWorks', () => {
+		it('updates display_order for all works', async () => {
+			const seasonWorkIds = ['sw-3', 'sw-1', 'sw-2'];
+
+			await reorderSeasonWorks(db, 'season-1', seasonWorkIds);
+
+			expect(db.batch).toHaveBeenCalledTimes(1);
+			expect(db.prepare).toHaveBeenCalledWith(
+				'UPDATE season_works SET display_order = ? WHERE id = ? AND season_id = ?'
+			);
+		});
+	});
+
+	describe('updateSeasonWorkNotes', () => {
+		it('updates notes and returns true', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				meta: { changes: 1 }
+			});
+
+			const result = await updateSeasonWorkNotes(db, 'sw-1', 'Performance notes');
+
+			expect(result).toBe(true);
+		});
+	});
+
+	describe('getSeasonWork', () => {
+		it('returns season work when found', async () => {
+			const mockRow = {
+				id: 'sw-1',
+				season_id: 'season-1',
+				work_id: 'work-1',
+				display_order: 0,
+				notes: null,
+				added_at: '2026-01-30T12:00:00Z',
+				added_by: 'member-1'
+			};
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockRow);
+
+			const result = await getSeasonWork(db, 'sw-1');
+
+			expect(result).toEqual(mockRow);
+		});
+
+		it('returns null when not found', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+			const result = await getSeasonWork(db, 'nonexistent');
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('isWorkInSeason', () => {
+		it('returns true when work exists in season', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ 1: 1 });
+
+			const result = await isWorkInSeason(db, 'season-1', 'work-1');
+
+			expect(result).toBe(true);
+		});
+
+		it('returns false when work not in season', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+			const result = await isWorkInSeason(db, 'season-1', 'work-1');
+
+			expect(result).toBe(false);
+		});
+	});
+});
+
+describe('Season Repertoire - Editions', () => {
+	let db: ReturnType<typeof createMockDb>;
+
+	beforeEach(() => {
+		db = createMockDb();
+	});
+
+	describe('addEditionToSeasonWork', () => {
+		it('adds edition and makes it primary if first', async () => {
+			// Mock: count returns 0 (first edition)
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ count: 0 });
+
+			const result = await addEditionToSeasonWork(db, {
+				seasonWorkId: 'sw-1',
+				editionId: 'edition-1',
+				addedBy: 'member-1'
+			});
+
+			expect(result.season_work_id).toBe('sw-1');
+			expect(result.edition_id).toBe('edition-1');
+			expect(result.is_primary).toBe(true); // First edition is primary
+			expect(result.id).toBeDefined();
+		});
+
+		it('adds non-primary edition when others exist', async () => {
+			// Mock: count returns 2 (existing editions)
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ count: 2 });
+
+			const result = await addEditionToSeasonWork(db, {
+				seasonWorkId: 'sw-1',
+				editionId: 'edition-2',
+				isPrimary: false
+			});
+
+			expect(result.is_primary).toBe(false);
+		});
+
+		it('clears existing primaries when adding as primary', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ count: 1 });
+
+			await addEditionToSeasonWork(db, {
+				seasonWorkId: 'sw-1',
+				editionId: 'edition-2',
+				isPrimary: true
+			});
+
+			// Should have called UPDATE to clear primaries
+			expect(db.prepare).toHaveBeenCalledWith(
+				'UPDATE season_work_editions SET is_primary = 0 WHERE season_work_id = ?'
+			);
+		});
+
+		it('throws error on duplicate edition', async () => {
+			(db.prepare('').first as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ count: 1 });
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+				new Error('UNIQUE constraint failed')
+			);
+
+			await expect(
+				addEditionToSeasonWork(db, { seasonWorkId: 'sw-1', editionId: 'edition-1' })
+			).rejects.toThrow('Edition is already selected for this work');
+		});
+	});
+
+	describe('removeEditionFromSeasonWork', () => {
+		it('returns true when edition removed', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				meta: { changes: 1 }
+			});
+
+			const result = await removeEditionFromSeasonWork(db, 'swe-1');
+
+			expect(result).toBe(true);
+		});
+
+		it('returns false when edition not found', async () => {
+			(db.prepare('').run as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				meta: { changes: 0 }
+			});
+
+			const result = await removeEditionFromSeasonWork(db, 'nonexistent');
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('setPrimaryEdition', () => {
+		it('clears other primaries and sets new primary', async () => {
+			await setPrimaryEdition(db, 'sw-1', 'swe-2');
+
+			// Should call UPDATE twice: clear all, then set one
+			expect(db.prepare).toHaveBeenCalledWith(
+				'UPDATE season_work_editions SET is_primary = 0 WHERE season_work_id = ?'
+			);
+			expect(db.prepare).toHaveBeenCalledWith(
+				'UPDATE season_work_editions SET is_primary = 1 WHERE id = ?'
+			);
+		});
+	});
+});
+
+describe('Season Repertoire - Queries', () => {
+	let db: ReturnType<typeof createMockDb>;
+
+	beforeEach(() => {
+		db = createMockDb();
+	});
+
+	describe('getSeasonRepertoire', () => {
+		it('returns empty works array when no works', async () => {
+			(db.prepare('').all as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ results: [] });
+
+			const result = await getSeasonRepertoire(db, 'season-1');
+
+			expect(result.seasonId).toBe('season-1');
+			expect(result.works).toEqual([]);
+		});
+
+		it('returns works with their editions', async () => {
+			// Mock season works query
+			const mockWorks = [
+				{
+					id: 'sw-1',
+					season_id: 'season-1',
+					work_id: 'work-1',
+					display_order: 0,
+					notes: null,
+					added_at: '2026-01-30T12:00:00Z',
+					added_by: null,
+					w_id: 'work-1',
+					w_title: 'Messiah',
+					w_composer: 'Handel',
+					w_lyricist: null,
+					w_created_at: '2026-01-30T12:00:00Z'
+				}
+			];
+			(db.prepare('').all as ReturnType<typeof vi.fn>)
+				.mockResolvedValueOnce({ results: mockWorks })
+				// Mock editions query
+				.mockResolvedValueOnce({
+					results: [
+						{
+							id: 'swe-1',
+							season_work_id: 'sw-1',
+							edition_id: 'ed-1',
+							is_primary: 1,
+							notes: null,
+							e_id: 'ed-1',
+							e_work_id: 'work-1',
+							e_name: 'Novello Vocal Score',
+							e_arranger: null,
+							e_publisher: 'Novello',
+							e_voicing: 'SATB',
+							e_edition_type: 'vocal_score',
+							e_license_type: 'public_domain',
+							e_notes: null,
+							e_external_url: null,
+							e_file_key: null,
+							e_file_name: null,
+							e_file_size: null,
+							e_created_at: '2026-01-30T12:00:00Z'
+						}
+					]
+				});
+
+			const result = await getSeasonRepertoire(db, 'season-1');
+
+			expect(result.works).toHaveLength(1);
+			expect(result.works[0].work.title).toBe('Messiah');
+			expect(result.works[0].seasonWorkId).toBe('sw-1');
+			expect(result.works[0].editions).toHaveLength(1);
+			expect(result.works[0].editions[0].edition.name).toBe('Novello Vocal Score');
+			expect(result.works[0].editions[0].isPrimary).toBe(true);
+			expect(result.works[0].editions[0].workEditionId).toBe('swe-1');
+		});
+	});
+});

--- a/apps/vault/src/lib/server/db/season-repertoire.ts
+++ b/apps/vault/src/lib/server/db/season-repertoire.ts
@@ -1,0 +1,370 @@
+// Season repertoire database operations
+// Two-stage: Works assigned to seasons, then Editions selected per work
+
+import { nanoid } from 'nanoid';
+import type { Work, Edition, SeasonRepertoireWork, SeasonRepertoireEdition, SeasonRepertoire } from '$lib/types';
+
+// Database row types
+export interface SeasonWork {
+	id: string;
+	season_id: string;
+	work_id: string;
+	display_order: number;
+	notes: string | null;
+	added_at: string;
+	added_by: string | null;
+}
+
+export interface SeasonWorkEdition {
+	id: string;
+	season_work_id: string;
+	edition_id: string;
+	is_primary: boolean;
+	notes: string | null;
+	added_at: string;
+	added_by: string | null;
+}
+
+// Re-export rich types for convenience
+export type { SeasonRepertoireWork, SeasonRepertoireEdition, SeasonRepertoire } from '$lib/types';
+
+// ============================================================================
+// SEASON WORKS OPERATIONS
+// ============================================================================
+
+/**
+ * Add a work to a season's repertoire
+ * @throws Error if work already exists in season (UNIQUE constraint)
+ */
+export async function addWorkToSeason(
+	db: D1Database,
+	seasonId: string,
+	workId: string,
+	addedBy: string | null = null,
+	notes: string | null = null
+): Promise<SeasonWork> {
+	const id = nanoid();
+
+	// Get next display order
+	const maxOrder = await db
+		.prepare('SELECT MAX(display_order) as max FROM season_works WHERE season_id = ?')
+		.bind(seasonId)
+		.first<{ max: number | null }>();
+
+	const displayOrder = (maxOrder?.max ?? -1) + 1;
+
+	try {
+		await db
+			.prepare(
+				'INSERT INTO season_works (id, season_id, work_id, display_order, notes, added_by) VALUES (?, ?, ?, ?, ?, ?)'
+			)
+			.bind(id, seasonId, workId, displayOrder, notes, addedBy)
+			.run();
+	} catch (error) {
+		if (error instanceof Error && error.message.includes('UNIQUE')) {
+			throw new Error('Work is already in this season\'s repertoire');
+		}
+		throw error;
+	}
+
+	return {
+		id,
+		season_id: seasonId,
+		work_id: workId,
+		display_order: displayOrder,
+		notes,
+		added_at: new Date().toISOString(),
+		added_by: addedBy
+	};
+}
+
+/**
+ * Remove a work from a season's repertoire
+ * Also removes all associated edition selections (CASCADE)
+ */
+export async function removeWorkFromSeason(
+	db: D1Database,
+	seasonWorkId: string
+): Promise<boolean> {
+	const result = await db
+		.prepare('DELETE FROM season_works WHERE id = ?')
+		.bind(seasonWorkId)
+		.run();
+
+	return (result.meta.changes ?? 0) > 0;
+}
+
+/**
+ * Reorder works in a season's repertoire
+ * @param seasonWorkIds - Array of season_work IDs in desired order
+ */
+export async function reorderSeasonWorks(
+	db: D1Database,
+	seasonId: string,
+	seasonWorkIds: string[]
+): Promise<void> {
+	const statements = seasonWorkIds.map((id, index) =>
+		db
+			.prepare('UPDATE season_works SET display_order = ? WHERE id = ? AND season_id = ?')
+			.bind(index, id, seasonId)
+	);
+
+	await db.batch(statements);
+}
+
+/**
+ * Update notes for a season work
+ */
+export async function updateSeasonWorkNotes(
+	db: D1Database,
+	seasonWorkId: string,
+	notes: string | null
+): Promise<boolean> {
+	const result = await db
+		.prepare('UPDATE season_works SET notes = ? WHERE id = ?')
+		.bind(notes, seasonWorkId)
+		.run();
+
+	return (result.meta.changes ?? 0) > 0;
+}
+
+// ============================================================================
+// SEASON WORK EDITIONS OPERATIONS
+// ============================================================================
+
+/** Options for adding an edition to a season work */
+export interface AddEditionOptions {
+	seasonWorkId: string;
+	editionId: string;
+	addedBy?: string | null;
+	isPrimary?: boolean;
+	notes?: string | null;
+}
+
+/** Determine if edition should be primary (first edition or explicitly set) */
+async function shouldBePrimaryEdition(db: D1Database, seasonWorkId: string, isPrimary: boolean): Promise<boolean> {
+	if (isPrimary) return true;
+	const result = await db
+		.prepare('SELECT COUNT(*) as count FROM season_work_editions WHERE season_work_id = ?')
+		.bind(seasonWorkId)
+		.first<{ count: number }>();
+	return (result?.count ?? 0) === 0;
+}
+
+/**
+ * Add an edition to a season work
+ * @throws Error if edition already exists for this season work (UNIQUE constraint)
+ */
+export async function addEditionToSeasonWork(db: D1Database, options: AddEditionOptions): Promise<SeasonWorkEdition> {
+	const { seasonWorkId, editionId, addedBy = null, isPrimary = false, notes = null } = options;
+	const id = nanoid();
+
+	// Clear existing primaries if this should be primary
+	if (isPrimary) {
+		await db.prepare('UPDATE season_work_editions SET is_primary = 0 WHERE season_work_id = ?').bind(seasonWorkId).run();
+	}
+
+	const finalIsPrimary = await shouldBePrimaryEdition(db, seasonWorkId, isPrimary);
+
+	try {
+		await db
+			.prepare('INSERT INTO season_work_editions (id, season_work_id, edition_id, is_primary, notes, added_by) VALUES (?, ?, ?, ?, ?, ?)')
+			.bind(id, seasonWorkId, editionId, finalIsPrimary ? 1 : 0, notes, addedBy)
+			.run();
+	} catch (e) {
+		if (e instanceof Error && e.message.includes('UNIQUE')) throw new Error('Edition is already selected for this work');
+		throw e;
+	}
+
+	return { id, season_work_id: seasonWorkId, edition_id: editionId, is_primary: finalIsPrimary, notes, added_at: new Date().toISOString(), added_by: addedBy };
+}
+
+/**
+ * Remove an edition from a season work
+ */
+export async function removeEditionFromSeasonWork(
+	db: D1Database,
+	seasonWorkEditionId: string
+): Promise<boolean> {
+	const result = await db
+		.prepare('DELETE FROM season_work_editions WHERE id = ?')
+		.bind(seasonWorkEditionId)
+		.run();
+
+	return (result.meta.changes ?? 0) > 0;
+}
+
+/**
+ * Set an edition as primary for a season work
+ */
+export async function setPrimaryEdition(
+	db: D1Database,
+	seasonWorkId: string,
+	seasonWorkEditionId: string
+): Promise<void> {
+	// Clear all primaries for this season work
+	await db
+		.prepare('UPDATE season_work_editions SET is_primary = 0 WHERE season_work_id = ?')
+		.bind(seasonWorkId)
+		.run();
+
+	// Set the new primary
+	await db
+		.prepare('UPDATE season_work_editions SET is_primary = 1 WHERE id = ?')
+		.bind(seasonWorkEditionId)
+		.run();
+}
+
+// ============================================================================
+// SEASON REPERTOIRE QUERIES
+// ============================================================================
+
+// Row types for queries
+interface SeasonWorkRow {
+	id: string;
+	season_id: string;
+	work_id: string;
+	display_order: number;
+	notes: string | null;
+	added_at: string;
+	added_by: string | null;
+	w_id: string;
+	w_title: string;
+	w_composer: string | null;
+	w_lyricist: string | null;
+	w_created_at: string;
+}
+
+interface EditionRow {
+	id: string;
+	season_work_id: string;
+	edition_id: string;
+	is_primary: number;
+	notes: string | null;
+	e_id: string;
+	e_work_id: string;
+	e_name: string;
+	e_arranger: string | null;
+	e_publisher: string | null;
+	e_voicing: string | null;
+	e_edition_type: string;
+	e_license_type: string;
+	e_notes: string | null;
+	e_external_url: string | null;
+	e_file_key: string | null;
+	e_file_name: string | null;
+	e_file_size: number | null;
+	e_created_at: string;
+}
+
+/** Convert edition row to SeasonRepertoireEdition */
+function mapEditionRow(e: EditionRow): SeasonRepertoireEdition {
+	const edition: Edition = {
+		id: e.e_id,
+		workId: e.e_work_id,
+		name: e.e_name,
+		arranger: e.e_arranger,
+		publisher: e.e_publisher,
+		voicing: e.e_voicing,
+		editionType: e.e_edition_type as Edition['editionType'],
+		licenseType: e.e_license_type as Edition['licenseType'],
+		notes: e.e_notes,
+		externalUrl: e.e_external_url,
+		fileKey: e.e_file_key,
+		fileName: e.e_file_name,
+		fileSize: e.e_file_size,
+		fileUploadedAt: null,
+		fileUploadedBy: null,
+		createdAt: e.e_created_at
+	};
+	return { workEditionId: e.id, edition, isPrimary: e.is_primary === 1, notes: e.notes };
+}
+
+/** Group editions by season work ID */
+function groupEditionsBySeasonWork(editions: EditionRow[]): Map<string, SeasonRepertoireEdition[]> {
+	const map = new Map<string, SeasonRepertoireEdition[]>();
+	for (const e of editions) {
+		const arr = map.get(e.season_work_id) ?? [];
+		arr.push(mapEditionRow(e));
+		map.set(e.season_work_id, arr);
+	}
+	return map;
+}
+
+/** Convert season work row to SeasonRepertoireWork */
+function mapSeasonWorkRow(sw: SeasonWorkRow, editionsMap: Map<string, SeasonRepertoireEdition[]>): SeasonRepertoireWork {
+	return {
+		seasonWorkId: sw.id,
+		work: { id: sw.w_id, title: sw.w_title, composer: sw.w_composer, lyricist: sw.w_lyricist, createdAt: sw.w_created_at },
+		displayOrder: sw.display_order,
+		notes: sw.notes,
+		editions: editionsMap.get(sw.id) ?? []
+	};
+}
+
+/**
+ * Get full repertoire for a season: works with their editions
+ */
+export async function getSeasonRepertoire(db: D1Database, seasonId: string): Promise<SeasonRepertoire> {
+	const seasonWorks = await db
+		.prepare(
+			`SELECT sw.id, sw.season_id, sw.work_id, sw.display_order, sw.notes, sw.added_at, sw.added_by,
+				w.id as w_id, w.title as w_title, w.composer as w_composer, w.lyricist as w_lyricist, w.created_at as w_created_at
+			FROM season_works sw JOIN works w ON sw.work_id = w.id WHERE sw.season_id = ? ORDER BY sw.display_order ASC`
+		)
+		.bind(seasonId)
+		.all<SeasonWorkRow>();
+
+	if (seasonWorks.results.length === 0) return { seasonId, works: [] };
+
+	const seasonWorkIds = seasonWorks.results.map(sw => sw.id);
+	const placeholders = seasonWorkIds.map(() => '?').join(',');
+
+	const editions = await db
+		.prepare(
+			`SELECT swe.id, swe.season_work_id, swe.edition_id, swe.is_primary, swe.notes,
+				e.id as e_id, e.work_id as e_work_id, e.name as e_name, e.arranger as e_arranger,
+				e.publisher as e_publisher, e.voicing as e_voicing, e.edition_type as e_edition_type,
+				e.license_type as e_license_type, e.notes as e_notes, e.external_url as e_external_url,
+				e.file_key as e_file_key, e.file_name as e_file_name, e.file_size as e_file_size, e.created_at as e_created_at
+			FROM season_work_editions swe JOIN editions e ON swe.edition_id = e.id
+			WHERE swe.season_work_id IN (${placeholders}) ORDER BY swe.is_primary DESC`
+		)
+		.bind(...seasonWorkIds)
+		.all<EditionRow>();
+
+	const editionsMap = groupEditionsBySeasonWork(editions.results);
+	const works = seasonWorks.results.map(sw => mapSeasonWorkRow(sw, editionsMap));
+	return { seasonId, works };
+}
+
+/**
+ * Get a single season work by ID
+ */
+export async function getSeasonWork(
+	db: D1Database,
+	seasonWorkId: string
+): Promise<SeasonWork | null> {
+	return await db
+		.prepare(
+			'SELECT id, season_id, work_id, display_order, notes, added_at, added_by FROM season_works WHERE id = ?'
+		)
+		.bind(seasonWorkId)
+		.first<SeasonWork>();
+}
+
+/**
+ * Check if a work is in a season's repertoire
+ */
+export async function isWorkInSeason(
+	db: D1Database,
+	seasonId: string,
+	workId: string
+): Promise<boolean> {
+	const result = await db
+		.prepare('SELECT 1 FROM season_works WHERE season_id = ? AND work_id = ?')
+		.bind(seasonId, workId)
+		.first();
+
+	return result !== null;
+}

--- a/apps/vault/src/lib/types.ts
+++ b/apps/vault/src/lib/types.ts
@@ -417,3 +417,37 @@ export interface CopyStats {
 	poor: number;
 	lost: number;
 }
+
+// ============================================================================
+// SEASON REPERTOIRE SYSTEM (Epic #106 Phase C)
+// ============================================================================
+
+/**
+ * Season repertoire work with editions
+ * Used by API/UI to display a work in a season's repertoire
+ */
+export interface SeasonRepertoireWork {
+	seasonWorkId: string; // season_works.id
+	work: Work;
+	displayOrder: number;
+	notes: string | null;
+	editions: SeasonRepertoireEdition[];
+}
+
+/**
+ * Edition selected for a work in a season
+ */
+export interface SeasonRepertoireEdition {
+	workEditionId: string; // season_work_editions.id
+	edition: Edition;
+	isPrimary: boolean;
+	notes: string | null;
+}
+
+/**
+ * Full season repertoire (works + editions tree)
+ */
+export interface SeasonRepertoire {
+	seasonId: string;
+	works: SeasonRepertoireWork[];
+}

--- a/apps/vault/src/routes/api/seasons/[id]/works/+server.ts
+++ b/apps/vault/src/routes/api/seasons/[id]/works/+server.ts
@@ -1,0 +1,47 @@
+// Season repertoire (works) API
+// GET /api/seasons/:id/works - Get all works in season
+// POST /api/seasons/:id/works - Add work to season
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getSeasonRepertoire, addWorkToSeason } from '$lib/server/db/season-repertoire';
+import { getSeason } from '$lib/server/db/seasons';
+import { getAuthenticatedMember, assertLibrarian } from '$lib/server/auth/middleware';
+
+async function requireSeason(db: D1Database, seasonId: string) {
+	const season = await getSeason(db, seasonId);
+	if (!season) throw error(404, 'Season not found');
+	return season;
+}
+
+export const GET: RequestHandler = async ({ params, platform }) => {
+	if (!platform?.env?.DB) throw error(500, 'Database not available');
+	const db = platform.env.DB;
+
+	await requireSeason(db, params.id);
+	const repertoire = await getSeasonRepertoire(db, params.id);
+	return json(repertoire);
+};
+
+export const POST: RequestHandler = async ({ params, request, platform, cookies }) => {
+	if (!platform?.env?.DB) throw error(500, 'Database not available');
+	const db = platform.env.DB;
+
+	const member = await getAuthenticatedMember(db, cookies);
+	assertLibrarian(member);
+	await requireSeason(db, params.id);
+
+	const body = await request.json() as { workId?: string; notes?: string };
+	if (!body.workId || typeof body.workId !== 'string') {
+		return json({ error: 'workId is required' }, { status: 400 });
+	}
+
+	try {
+		const seasonWork = await addWorkToSeason(db, params.id, body.workId, member.id, body.notes ?? null);
+		return json(seasonWork, { status: 201 });
+	} catch (err) {
+		if (err instanceof Error && err.message.includes('already in this season')) {
+			return json({ error: err.message }, { status: 409 });
+		}
+		throw err;
+	}
+};

--- a/apps/vault/src/routes/api/seasons/[id]/works/[workId]/+server.ts
+++ b/apps/vault/src/routes/api/seasons/[id]/works/[workId]/+server.ts
@@ -1,0 +1,56 @@
+// Season repertoire work API
+// DELETE /api/seasons/:id/works/:workId - Remove work from season
+// PATCH /api/seasons/:id/works/:workId - Update work notes
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { removeWorkFromSeason, updateSeasonWorkNotes, getSeasonWork } from '$lib/server/db/season-repertoire';
+import { getSeason } from '$lib/server/db/seasons';
+import { getAuthenticatedMember, assertLibrarian } from '$lib/server/auth/middleware';
+
+async function requireSeasonWork(db: D1Database, seasonId: string, seasonWorkId: string) {
+	const season = await getSeason(db, seasonId);
+	if (!season) throw error(404, 'Season not found');
+
+	const seasonWork = await getSeasonWork(db, seasonWorkId);
+	if (!seasonWork || seasonWork.season_id !== seasonId) {
+		throw error(404, 'Work not found in season');
+	}
+	return seasonWork;
+}
+
+export const DELETE: RequestHandler = async ({ params, platform, cookies }) => {
+	if (!platform?.env?.DB) throw error(500, 'Database not available');
+
+	const db = platform.env.DB;
+	const member = await getAuthenticatedMember(db, cookies);
+	assertLibrarian(member);
+
+	await requireSeasonWork(db, params.id, params.workId);
+	await removeWorkFromSeason(db, params.workId);
+
+	return new Response(null, { status: 204 });
+};
+
+export const PATCH: RequestHandler = async ({ params, request, platform, cookies }) => {
+	if (!platform?.env?.DB) throw error(500, 'Database not available');
+
+	const db = platform.env.DB;
+	const member = await getAuthenticatedMember(db, cookies);
+	assertLibrarian(member);
+
+	await requireSeasonWork(db, params.id, params.workId);
+
+	let body: { notes?: string | null };
+	try {
+		body = await request.json();
+	} catch {
+		throw error(400, 'Invalid JSON body');
+	}
+
+	if (body.notes !== undefined) {
+		await updateSeasonWorkNotes(db, params.workId, body.notes ?? null);
+	}
+
+	const updated = await getSeasonWork(db, params.workId);
+	return json(updated);
+};

--- a/apps/vault/src/routes/api/seasons/[id]/works/[workId]/editions/+server.ts
+++ b/apps/vault/src/routes/api/seasons/[id]/works/[workId]/editions/+server.ts
@@ -1,0 +1,47 @@
+// Season work editions API
+// POST /api/seasons/:id/works/:workId/editions - Add edition to work
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { addEditionToSeasonWork, getSeasonWork } from '$lib/server/db/season-repertoire';
+import { getSeason } from '$lib/server/db/seasons';
+import { getAuthenticatedMember, assertLibrarian } from '$lib/server/auth/middleware';
+
+async function requireSeasonWork(db: D1Database, seasonId: string, seasonWorkId: string) {
+	const season = await getSeason(db, seasonId);
+	if (!season) throw error(404, 'Season not found');
+
+	const seasonWork = await getSeasonWork(db, seasonWorkId);
+	if (!seasonWork || seasonWork.season_id !== seasonId) throw error(404, 'Work not found in season');
+	return seasonWork;
+}
+
+async function parseAndValidateBody(request: Request): Promise<{ editionId: string; isPrimary?: boolean; notes?: string }> {
+	const body = await request.json().catch(() => { throw error(400, 'Invalid JSON body'); }) as Record<string, unknown>;
+	if (!body.editionId || typeof body.editionId !== 'string') throw error(400, 'editionId is required');
+	return { editionId: body.editionId, isPrimary: body.isPrimary as boolean | undefined, notes: body.notes as string | undefined };
+}
+
+export const POST: RequestHandler = async ({ params, request, platform, cookies }) => {
+	if (!platform?.env?.DB) throw error(500, 'Database not available');
+
+	const db = platform.env.DB;
+	const member = await getAuthenticatedMember(db, cookies);
+	assertLibrarian(member);
+
+	await requireSeasonWork(db, params.id, params.workId);
+	const body = await parseAndValidateBody(request);
+
+	try {
+		const workEdition = await addEditionToSeasonWork(db, {
+			seasonWorkId: params.workId,
+			editionId: body.editionId,
+			addedBy: member.id,
+			isPrimary: body.isPrimary ?? false,
+			notes: body.notes ?? null
+		});
+		return json(workEdition, { status: 201 });
+	} catch (e) {
+		if (e instanceof Error && e.message.includes('already selected')) throw error(409, e.message);
+		throw e;
+	}
+};

--- a/apps/vault/src/routes/api/seasons/[id]/works/[workId]/editions/[editionId]/+server.ts
+++ b/apps/vault/src/routes/api/seasons/[id]/works/[workId]/editions/[editionId]/+server.ts
@@ -1,0 +1,56 @@
+// Season work edition API
+// DELETE /api/seasons/:id/works/:workId/editions/:editionId - Remove edition from work
+// PATCH /api/seasons/:id/works/:workId/editions/:editionId - Set as primary
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { removeEditionFromSeasonWork, setPrimaryEdition, getSeasonWork } from '$lib/server/db/season-repertoire';
+import { getSeason } from '$lib/server/db/seasons';
+import { getAuthenticatedMember, assertLibrarian } from '$lib/server/auth/middleware';
+
+async function requireSeasonWork(db: D1Database, seasonId: string, seasonWorkId: string) {
+	const season = await getSeason(db, seasonId);
+	if (!season) throw error(404, 'Season not found');
+
+	const seasonWork = await getSeasonWork(db, seasonWorkId);
+	if (!seasonWork || seasonWork.season_id !== seasonId) {
+		throw error(404, 'Work not found in season');
+	}
+	return seasonWork;
+}
+
+export const DELETE: RequestHandler = async ({ params, platform, cookies }) => {
+	if (!platform?.env?.DB) throw error(500, 'Database not available');
+
+	const db = platform.env.DB;
+	const member = await getAuthenticatedMember(db, cookies);
+	assertLibrarian(member);
+
+	await requireSeasonWork(db, params.id, params.workId);
+	const deleted = await removeEditionFromSeasonWork(db, params.editionId);
+	if (!deleted) throw error(404, 'Edition not found');
+
+	return new Response(null, { status: 204 });
+};
+
+export const PATCH: RequestHandler = async ({ params, request, platform, cookies }) => {
+	if (!platform?.env?.DB) throw error(500, 'Database not available');
+
+	const db = platform.env.DB;
+	const member = await getAuthenticatedMember(db, cookies);
+	assertLibrarian(member);
+
+	await requireSeasonWork(db, params.id, params.workId);
+
+	let body: { isPrimary?: boolean };
+	try {
+		body = await request.json();
+	} catch {
+		throw error(400, 'Invalid JSON body');
+	}
+
+	if (body.isPrimary === true) {
+		await setPrimaryEdition(db, params.workId, params.editionId);
+	}
+
+	return json({ success: true });
+};

--- a/apps/vault/src/routes/api/seasons/[id]/works/reorder/+server.ts
+++ b/apps/vault/src/routes/api/seasons/[id]/works/reorder/+server.ts
@@ -1,0 +1,32 @@
+// Season works reorder API
+// POST /api/seasons/:id/works/reorder - Reorder works in season
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { reorderSeasonWorks } from '$lib/server/db/season-repertoire';
+import { getSeason } from '$lib/server/db/seasons';
+import { getAuthenticatedMember, assertLibrarian } from '$lib/server/auth/middleware';
+
+export const POST: RequestHandler = async ({ params, request, platform, cookies }) => {
+	if (!platform?.env?.DB) throw error(500, 'Database not available');
+
+	const db = platform.env.DB;
+	const member = await getAuthenticatedMember(db, cookies);
+	assertLibrarian(member);
+
+	const season = await getSeason(db, params.id);
+	if (!season) throw error(404, 'Season not found');
+
+	let body: { seasonWorkIds: string[] };
+	try {
+		body = await request.json();
+	} catch {
+		throw error(400, 'Invalid JSON body');
+	}
+
+	if (!Array.isArray(body.seasonWorkIds) || body.seasonWorkIds.length === 0) {
+		throw error(400, 'seasonWorkIds array is required');
+	}
+
+	await reorderSeasonWorks(db, params.id, body.seasonWorkIds);
+	return json({ success: true });
+};

--- a/apps/vault/src/routes/seasons/[id]/+page.server.ts
+++ b/apps/vault/src/routes/seasons/[id]/+page.server.ts
@@ -1,9 +1,10 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getMemberById } from '$lib/server/db/members';
-import { canManageEvents } from '$lib/server/auth/permissions';
+import { canManageEvents, canUploadScores } from '$lib/server/auth/permissions';
 import type { Season } from '$lib/server/db/seasons';
 import type { Event } from '$lib/server/db/events';
+import type { SeasonRepertoire, Work } from '$lib/types';
 
 interface SeasonWithEvents extends Season {
 	events: Event[];
@@ -16,19 +17,30 @@ export const load: PageServerLoad = async ({ params, fetch, platform, cookies })
 	}
 
 	// Fetch season with events
-	const response = await fetch(`/api/seasons/${seasonId}?events=true`);
+	const [seasonResponse, repertoireResponse, worksResponse] = await Promise.all([
+		fetch(`/api/seasons/${seasonId}?events=true`),
+		fetch(`/api/seasons/${seasonId}/works`),
+		fetch(`/api/works`)
+	]);
 	
-	if (!response.ok) {
-		if (response.status === 404) {
+	if (!seasonResponse.ok) {
+		if (seasonResponse.status === 404) {
 			throw error(404, 'Season not found');
 		}
-		throw error(response.status, 'Failed to load season');
+		throw error(seasonResponse.status, 'Failed to load season');
 	}
 
-	const season = (await response.json()) as SeasonWithEvents;
+	const season = (await seasonResponse.json()) as SeasonWithEvents;
+	const repertoire = repertoireResponse.ok 
+		? (await repertoireResponse.json()) as SeasonRepertoire 
+		: { seasonId, works: [] };
+	const allWorks = worksResponse.ok 
+		? (await worksResponse.json()) as Work[] 
+		: [];
 
 	// Get current user's permissions
 	let canManage = false;
+	let canManageLibrary = false;
 
 	const db = platform?.env?.DB;
 	const memberId = cookies.get('member_id');
@@ -37,12 +49,20 @@ export const load: PageServerLoad = async ({ params, fetch, platform, cookies })
 		const member = await getMemberById(db, memberId);
 		if (member) {
 			canManage = canManageEvents(member);
+			canManageLibrary = canUploadScores(member);
 		}
 	}
+
+	// Filter out works already in repertoire for the add dropdown
+	const repertoireWorkIds = new Set(repertoire.works.map(w => w.work.id));
+	const availableWorks = allWorks.filter(w => !repertoireWorkIds.has(w.id));
 
 	return {
 		season,
 		events: season.events ?? [],
-		canManage
+		repertoire,
+		availableWorks,
+		canManage,
+		canManageLibrary
 	};
 };

--- a/apps/vault/src/routes/seasons/[id]/+page.svelte
+++ b/apps/vault/src/routes/seasons/[id]/+page.svelte
@@ -1,8 +1,27 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import type { PageData } from './$types';
 	import Card from '$lib/components/Card.svelte';
+	import type { SeasonRepertoireWork, SeasonRepertoire, Work } from '$lib/types';
 
 	let { data }: { data: PageData } = $props();
+
+	// Local state for repertoire (reactive copy) - explicit types for filter/find callbacks
+	let repertoire: SeasonRepertoire = $state(untrack(() => data.repertoire));
+	let availableWorks: Work[] = $state(untrack(() => data.availableWorks));
+
+	// State for UI interactions
+	let selectedWorkId = $state('');
+	let addingWork = $state(false);
+	let removingWorkId = $state<string | null>(null);
+	let error = $state('');
+	let expandedWorkId = $state<string | null>(null);
+
+	// Sync on navigation
+	$effect(() => {
+		repertoire = data.repertoire;
+		availableWorks = data.availableWorks;
+	});
 
 	function formatDateTime(isoString: string): string {
 		const date = new Date(isoString);
@@ -24,6 +43,86 @@
 				return { bg: 'bg-blue-100', text: 'text-blue-800' };
 			case 'retreat':
 				return { bg: 'bg-green-100', text: 'text-green-800' };
+			default:
+				return { bg: 'bg-gray-100', text: 'text-gray-800' };
+		}
+	}
+
+	async function addWorkToSeason() {
+		if (!selectedWorkId) return;
+
+		addingWork = true;
+		error = '';
+
+		try {
+			const response = await fetch(`/api/seasons/${data.season.id}/works`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ workId: selectedWorkId })
+			});
+
+			if (!response.ok) {
+			const result = await response.json() as { error?: string };
+			}
+
+			// Refresh repertoire
+			const repertoireResponse = await fetch(`/api/seasons/${data.season.id}/works`);
+			if (repertoireResponse.ok) {
+				repertoire = await repertoireResponse.json();
+			}
+
+			// Update available works
+			availableWorks = availableWorks.filter(w => w.id !== selectedWorkId);
+			selectedWorkId = '';
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to add work';
+		} finally {
+			addingWork = false;
+		}
+	}
+
+	async function removeWorkFromSeason(seasonWorkId: string, workId: string) {
+		if (!confirm('Remove this work from the season repertoire?')) return;
+
+		removingWorkId = seasonWorkId;
+		error = '';
+
+		try {
+			const response = await fetch(`/api/seasons/${data.season.id}/works/${seasonWorkId}`, {
+				method: 'DELETE'
+			});
+
+			if (!response.ok) {
+				throw new Error('Failed to remove work');
+			}
+
+			// Update local state
+			const removedWork = repertoire.works.find(w => w.seasonWorkId === seasonWorkId);
+			repertoire = { ...repertoire, works: repertoire.works.filter(w => w.seasonWorkId !== seasonWorkId) };
+			
+			// Add back to available works
+			if (removedWork) {
+				availableWorks = [...availableWorks, removedWork.work].sort((a, b) => a.title.localeCompare(b.title));
+			}
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to remove work';
+		} finally {
+			removingWorkId = null;
+		}
+	}
+
+	function toggleExpanded(seasonWorkId: string) {
+		expandedWorkId = expandedWorkId === seasonWorkId ? null : seasonWorkId;
+	}
+
+	function getLicenseBadge(licenseType: string): { bg: string; text: string } {
+		switch (licenseType) {
+			case 'public_domain':
+				return { bg: 'bg-green-100', text: 'text-green-800' };
+			case 'licensed':
+				return { bg: 'bg-amber-100', text: 'text-amber-800' };
+			case 'owned':
+				return { bg: 'bg-blue-100', text: 'text-blue-800' };
 			default:
 				return { bg: 'bg-gray-100', text: 'text-gray-800' };
 		}
@@ -50,6 +149,151 @@
 			})}
 		</p>
 	</div>
+
+	{#if error}
+		<div class="mb-4 rounded-lg bg-red-100 p-4 text-red-700">
+			{error}
+			<button onclick={() => error = ''} class="ml-2 text-red-800 hover:underline">Dismiss</button>
+		</div>
+	{/if}
+
+	<!-- Repertoire Section -->
+	<section class="mb-8">
+		<div class="mb-4 flex items-center justify-between">
+			<h2 class="text-xl font-semibold">Season Repertoire</h2>
+		</div>
+
+		{#if data.canManageLibrary && availableWorks.length > 0}
+			<div class="mb-4 flex gap-2">
+				<select 
+					bind:value={selectedWorkId}
+					class="flex-1 rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+					disabled={addingWork}
+				>
+					<option value="">Select a work to add...</option>
+					{#each availableWorks as work (work.id)}
+						<option value={work.id}>
+							{work.title}{work.composer ? ` - ${work.composer}` : ''}
+						</option>
+					{/each}
+				</select>
+				<button
+					onclick={addWorkToSeason}
+					disabled={!selectedWorkId || addingWork}
+					class="rounded-lg bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700 disabled:opacity-50"
+				>
+					{addingWork ? 'Adding...' : 'Add Work'}
+				</button>
+			</div>
+		{/if}
+
+		{#if repertoire.works.length === 0}
+			<Card padding="lg">
+				<div class="py-8 text-center text-gray-500">
+					<p>No works in this season's repertoire yet.</p>
+					{#if availableWorks.length === 0}
+						<p class="mt-2">
+							<a href="/library/works/new" class="text-blue-600 hover:underline">
+								Add works to the library first
+							</a>
+						</p>
+					{/if}
+				</div>
+			</Card>
+		{:else}
+			<div class="space-y-3">
+				{#each repertoire.works as repWork (repWork.seasonWorkId)}
+					<Card padding="md">
+						<div class="flex items-start justify-between">
+							<div class="flex-1">
+								<button
+									onclick={() => toggleExpanded(repWork.seasonWorkId)}
+									class="flex items-center gap-2 text-left hover:text-blue-600"
+								>
+									<span class="text-gray-400 transition-transform" class:rotate-90={expandedWorkId === repWork.seasonWorkId}>
+										▶
+									</span>
+									<h3 class="font-medium">{repWork.work.title}</h3>
+								</button>
+								{#if repWork.work.composer}
+									<p class="ml-6 text-sm text-gray-600">{repWork.work.composer}</p>
+								{/if}
+								{#if repWork.notes}
+									<p class="ml-6 mt-1 text-sm italic text-gray-500">{repWork.notes}</p>
+								{/if}
+								
+								<!-- Editions summary -->
+								<div class="ml-6 mt-1 text-xs text-gray-500">
+									{#if repWork.editions.length === 0}
+										<span class="text-amber-600">No editions selected</span>
+									{:else if repWork.editions.length === 1}
+										<span>1 edition</span>
+									{:else}
+										<span>{repWork.editions.length} editions</span>
+									{/if}
+								</div>
+							</div>
+
+							{#if data.canManageLibrary}
+								<button
+									onclick={() => removeWorkFromSeason(repWork.seasonWorkId, repWork.work.id)}
+									disabled={removingWorkId === repWork.seasonWorkId}
+									class="text-red-600 hover:text-red-800 disabled:opacity-50"
+									title="Remove from repertoire"
+								>
+									{removingWorkId === repWork.seasonWorkId ? '...' : '✕'}
+								</button>
+							{/if}
+						</div>
+
+						<!-- Expanded editions list -->
+						{#if expandedWorkId === repWork.seasonWorkId}
+							<div class="ml-6 mt-4 border-t pt-4">
+								<h4 class="mb-2 text-sm font-medium text-gray-700">Editions:</h4>
+								{#if repWork.editions.length === 0}
+									<p class="text-sm text-gray-500">
+										No editions selected. 
+										<a href="/library/works/{repWork.work.id}" class="text-blue-600 hover:underline">
+											View work editions
+										</a>
+									</p>
+								{:else}
+									<ul class="space-y-2">
+										{#each repWork.editions as ed (ed.workEditionId)}
+											{@const badge = getLicenseBadge(ed.edition.licenseType)}
+											<li class="flex items-center gap-2 text-sm">
+												{#if ed.isPrimary}
+													<span class="text-amber-500" title="Primary edition">★</span>
+												{:else}
+													<span class="text-gray-300">☆</span>
+												{/if}
+												<a 
+													href="/library/editions/{ed.edition.id}" 
+													class="hover:text-blue-600 hover:underline"
+												>
+													{ed.edition.name}
+												</a>
+												<span class="{badge.bg} {badge.text} rounded px-1.5 py-0.5 text-xs">
+													{ed.edition.licenseType.replace('_', ' ')}
+												</span>
+												{#if ed.edition.voicing}
+													<span class="text-gray-400">({ed.edition.voicing})</span>
+												{/if}
+											</li>
+										{/each}
+									</ul>
+								{/if}
+							</div>
+						{/if}
+					</Card>
+				{/each}
+			</div>
+
+			<p class="mt-4 text-sm text-gray-500">
+				{repertoire.works.length} work{repertoire.works.length === 1 ? '' : 's'} in repertoire
+			</p>
+		{/if}
+	</section>
 
 	<!-- Events in this season -->
 	<section>


### PR DESCRIPTION
## Summary
Implements #120 - Season Repertoire Management

Adds two-stage repertoire system for seasons:
1. **Works assigned to seasons** - with display_order for ordering
2. **Editions selected per work** - with primary edition designation

## Database Changes

### Migration 0023_season_repertoire.sql
- `season_works` junction table: season_id, work_id, display_order, notes
- `season_work_editions` junction table: season_work_id, edition_id, is_primary, notes
- UNIQUE constraints prevent duplicate assignments
- CASCADE deletes maintain referential integrity
- Indexes for efficient queries

## DB Layer (season-repertoire.ts)

### Works Operations
- `addWorkToSeason()` - auto-increment display_order
- `removeWorkFromSeason()` - cascades to editions
- `reorderSeasonWorks()` - batch update for drag-and-drop

### Editions Operations
- `addEditionToSeasonWork()` - first edition auto-becomes primary
- `removeEditionFromSeasonWork()`
- `setPrimaryEdition()` - clears others, sets new primary

### Queries
- `getSeasonRepertoire()` - full tree query with JOINs to works and editions
- `getSeasonWork()`, `isWorkInSeason()`

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/seasons/:id/works` | Get season repertoire |
| POST | `/api/seasons/:id/works` | Add work to season |
| DELETE | `/api/seasons/:id/works/:workId` | Remove work |
| PATCH | `/api/seasons/:id/works/:workId` | Update work notes |
| POST | `/api/seasons/:id/works/:workId/editions` | Add edition |
| DELETE | `/api/seasons/:id/works/:workId/editions/:editionId` | Remove edition |
| PATCH | `/api/seasons/:id/works/:workId/editions/:editionId` | Set as primary |
| POST | `/api/seasons/:id/works/reorder` | Reorder works |

All mutating endpoints require librarian role.

## UI Changes

Season detail page (`/seasons/[id]`) now includes:
- Repertoire section above events
- Dropdown to add works from library
- Expandable work cards showing selected editions
- Remove works from repertoire (librarians only)
- Edition list with primary star indicator

## Testing

- 20 unit tests for season-repertoire.ts
- All 545 tests passing (483 vault + 62 registry)
- TypeScript check passing

## Closes #120