### PR TITLE
feat: Add Inventory Reports page

### DIFF
--- a/.github/DEVELOPER-WORKFLOW.md
+++ b/.github/DEVELOPER-WORKFLOW.md
@@ -384,6 +384,7 @@ Refs: #67
 **Lead responsibility:**
 
 Before session end, Lead must verify:
+
 1. No "dangling" issues (implemented but not closed)
 2. All merged work has corresponding closed issues
 3. Epic issue has sub-issues checked off as completed

--- a/apps/vault/src/routes/library/inventory/+page.server.ts
+++ b/apps/vault/src/routes/library/inventory/+page.server.ts
@@ -1,0 +1,39 @@
+// Inventory reports page server loader
+// Issue #118: Librarian tools for managing physical inventory
+import { error, redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { getMemberById } from '$lib/server/db/members';
+import { canUploadScores } from '$lib/server/auth/permissions';
+import { getEditionInventorySummaries } from '$lib/server/db/physical-copies';
+
+export const load: PageServerLoad = async ({ platform, cookies }) => {
+	if (!platform?.env?.DB) {
+		throw error(500, 'Database unavailable');
+	}
+
+	const db = platform.env.DB;
+	const memberId = cookies.get('member_id');
+
+	// Require authentication
+	if (!memberId) {
+		throw redirect(303, '/welcome');
+	}
+
+	// Get member and check permissions
+	const member = await getMemberById(db, memberId);
+	if (!member) {
+		throw redirect(303, '/welcome');
+	}
+
+	// Permission check: librarian/admin/owner only
+	if (!canUploadScores(member)) {
+		throw redirect(303, '/works');
+	}
+
+	// Load inventory summaries
+	const summaries = await getEditionInventorySummaries(db);
+
+	return {
+		summaries
+	};
+};

--- a/apps/vault/src/routes/library/inventory/+page.svelte
+++ b/apps/vault/src/routes/library/inventory/+page.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import Card from '$lib/components/Card.svelte';
+
+	let { data }: { data: PageData } = $props();
+
+	// Calculate totals
+	const totals = $derived({
+		copies: data.summaries.reduce((sum, s) => sum + s.total, 0),
+		available: data.summaries.reduce((sum, s) => sum + s.available, 0),
+		assigned: data.summaries.reduce((sum, s) => sum + s.assigned, 0),
+		lost: data.summaries.reduce((sum, s) => sum + s.lost, 0)
+	});
+</script>
+
+<svelte:head>
+	<title>Inventory Reports | Polyphony Vault</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-6xl px-4 py-8">
+	<!-- Header -->
+	<div class="mb-8">
+		<nav class="mb-4 text-sm text-gray-500">
+			<a href="/works" class="hover:text-blue-600">Library</a>
+			<span class="mx-2">›</span>
+			<span>Inventory</span>
+		</nav>
+		<h1 class="text-3xl font-bold">Inventory Reports</h1>
+		<p class="mt-2 text-gray-600">Physical copy inventory summary per edition</p>
+	</div>
+
+	<!-- Summary Stats -->
+	<div class="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
+		<Card>
+			<div class="text-center">
+				<div class="text-3xl font-bold text-gray-900">{totals.copies}</div>
+				<div class="text-sm text-gray-500">Total Copies</div>
+			</div>
+		</Card>
+		<Card>
+			<div class="text-center">
+				<div class="text-3xl font-bold text-green-600">{totals.available}</div>
+				<div class="text-sm text-gray-500">Available</div>
+			</div>
+		</Card>
+		<Card>
+			<div class="text-center">
+				<div class="text-3xl font-bold text-blue-600">{totals.assigned}</div>
+				<div class="text-sm text-gray-500">Assigned</div>
+			</div>
+		</Card>
+		<Card>
+			<div class="text-center">
+				<div class="text-3xl font-bold text-red-600">{totals.lost}</div>
+				<div class="text-sm text-gray-500">Lost</div>
+			</div>
+		</Card>
+	</div>
+
+	<!-- Inventory Table -->
+	<Card>
+		{#if data.summaries.length === 0}
+			<div class="py-12 text-center text-gray-500">
+				<p>No physical copies in inventory.</p>
+				<p class="mt-2 text-sm">
+					Add physical copies to editions from the
+					<a href="/works" class="text-blue-600 hover:underline">works library</a>.
+				</p>
+			</div>
+		{:else}
+			<div class="overflow-x-auto">
+				<table class="w-full">
+					<thead>
+						<tr class="border-b text-left text-sm font-medium text-gray-500">
+							<th class="pb-3 pr-4">Work</th>
+							<th class="pb-3 pr-4">Edition</th>
+							<th class="pb-3 pr-4 text-right">Total</th>
+							<th class="pb-3 pr-4 text-right">Available</th>
+							<th class="pb-3 pr-4 text-right">Assigned</th>
+							<th class="pb-3 text-right">Lost</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each data.summaries as summary}
+							<tr class="border-b last:border-0 hover:bg-gray-50">
+								<td class="py-3 pr-4">
+									<div class="font-medium text-gray-900">{summary.workTitle}</div>
+									{#if summary.composer}
+										<div class="text-sm text-gray-500">{summary.composer}</div>
+									{/if}
+								</td>
+								<td class="py-3 pr-4">
+									<a
+										href="/editions/{summary.editionId}"
+										class="text-blue-600 hover:underline"
+									>
+										{summary.editionName}
+									</a>
+								</td>
+								<td class="py-3 pr-4 text-right font-medium">{summary.total}</td>
+								<td class="py-3 pr-4 text-right">
+									{#if summary.available > 0}
+										<span class="rounded-full bg-green-100 px-2 py-1 text-sm font-medium text-green-800">
+											{summary.available}
+										</span>
+									{:else}
+										<span class="text-gray-400">0</span>
+									{/if}
+								</td>
+								<td class="py-3 pr-4 text-right">
+									{#if summary.assigned > 0}
+										<span class="rounded-full bg-blue-100 px-2 py-1 text-sm font-medium text-blue-800">
+											{summary.assigned}
+										</span>
+									{:else}
+										<span class="text-gray-400">0</span>
+									{/if}
+								</td>
+								<td class="py-3 text-right">
+									{#if summary.lost > 0}
+										<span class="rounded-full bg-red-100 px-2 py-1 text-sm font-medium text-red-800">
+											{summary.lost}
+										</span>
+									{:else}
+										<span class="text-gray-400">0</span>
+									{/if}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	</Card>
+</div>

--- a/apps/vault/src/routes/works/+page.svelte
+++ b/apps/vault/src/routes/works/+page.svelte
@@ -156,14 +156,22 @@
 			<h1 class="text-3xl font-bold">Works Catalog</h1>
 			<p class="mt-1 text-gray-600">Musical compositions in your library</p>
 		</div>
-		{#if data.canManage}
-			<button
-				onclick={openCreateForm}
-				class="rounded-lg bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700"
-			>
-				+ Add Work
-			</button>
-		{/if}
+		<div class="flex gap-3">
+			{#if data.canManage}
+				<a
+					href="/library/inventory"
+					class="rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-50"
+				>
+					Inventory
+				</a>
+				<button
+					onclick={openCreateForm}
+					class="rounded-lg bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700"
+				>
+					+ Add Work
+				</button>
+			{/if}
+		</div>
 	</div>
 
 	{#if error}


### PR DESCRIPTION
## Summary
Adds librarian tools for viewing physical copy inventory. Part of Epic #106 - Phase D.

## Changes

### Database Layer (`physical-copies.ts`)
- `getEditionInventorySummaries()` - total/available/assigned/lost counts per edition
- `getUnassignedCopies(editionId)` - copies available for checkout
- `getCopiesByCondition(editionId, condition)` - filter by condition

### UI (`/library/inventory`)
- Summary stat cards: Total, Available, Assigned, Lost
- Edition inventory table with:
  - Work title + composer
  - Edition name (links to edition detail)
  - Count badges (green=available, blue=assigned, red=lost)
- Permission: Librarian/Admin/Owner only

### Navigation
- Added "Inventory" button to Works Catalog page (visible to librarians)

## Testing
- ✅ 7 new unit tests for query functions
- ✅ 780 vault tests passing
- ✅ 862 total tests passing
- ✅ TypeScript: 0 errors

## Screenshots
_[UI shows summary cards + inventory table]_

Closes #118