### PR TITLE
feat(vault): Add missing copies report (#123)

### DIFF
--- a/apps/vault/src/lib/server/db/inventory-reports.ts
+++ b/apps/vault/src/lib/server/db/inventory-reports.ts
@@ -1,0 +1,167 @@
+// Inventory report queries
+// Issue #123 - Missing Copies Report
+// Part of Epic #106 - Phase D: Reports & Insights
+
+export interface MissingCopyEntry {
+	memberId: string;
+	memberName: string;
+	sectionId: string;
+	sectionName: string;
+	editionId: string;
+	editionName: string;
+	workId: string;
+	workTitle: string;
+	composer: string | null;
+}
+
+export interface MissingCopiesReport {
+	entries: MissingCopyEntry[];
+	totalMissing: number;
+	editionCount: number;
+}
+
+interface MissingCopyRow {
+	member_id: string;
+	member_name: string;
+	section_id: string;
+	section_name: string;
+	edition_id: string;
+	edition_name: string;
+	work_id: string;
+	work_title: string;
+	composer: string | null;
+}
+
+/**
+ * Get missing copies report for an event
+ *
+ * Logic:
+ * 1. Get all editions in event repertoire (event_works → event_work_editions)
+ * 2. For each edition, find relevant sections (edition_sections)
+ * 3. Find members in those sections (member_sections)
+ * 4. Exclude members who already have a copy assigned (NOT EXISTS subquery)
+ *
+ * Uses NOT EXISTS pattern instead of LEFT JOIN + NULL check
+ * to avoid row multiplication and allow SQLite short-circuit optimization.
+ */
+export async function getMissingCopiesForEvent(
+	db: D1Database,
+	eventId: string
+): Promise<MissingCopiesReport> {
+	const query = `
+		SELECT 
+			m.id as member_id,
+			m.name as member_name,
+			s.id as section_id,
+			s.name as section_name,
+			e.id as edition_id,
+			e.name as edition_name,
+			w.id as work_id,
+			w.title as work_title,
+			w.composer
+		FROM event_works ew
+		JOIN event_work_editions ewe ON ewe.event_work_id = ew.id
+		JOIN editions e ON e.id = ewe.edition_id
+		JOIN works w ON w.id = e.work_id
+		JOIN edition_sections es ON es.edition_id = e.id
+		JOIN member_sections ms ON ms.section_id = es.section_id
+		JOIN members m ON m.id = ms.member_id
+		JOIN sections s ON s.id = ms.section_id
+		WHERE ew.event_id = ?
+			AND m.email_id IS NOT NULL
+			AND NOT EXISTS (
+				SELECT 1 
+				FROM physical_copies pc
+				JOIN copy_assignments ca ON ca.copy_id = pc.id
+				WHERE pc.edition_id = e.id
+					AND ca.member_id = m.id
+					AND ca.returned_at IS NULL
+			)
+		ORDER BY w.title, e.name, s.name, m.name
+	`;
+
+	const { results } = await db.prepare(query).bind(eventId).all<MissingCopyRow>();
+
+	const entries: MissingCopyEntry[] = results.map((row) => ({
+		memberId: row.member_id,
+		memberName: row.member_name,
+		sectionId: row.section_id,
+		sectionName: row.section_name,
+		editionId: row.edition_id,
+		editionName: row.edition_name,
+		workId: row.work_id,
+		workTitle: row.work_title,
+		composer: row.composer
+	}));
+
+	const uniqueEditions = new Set(entries.map((e) => e.editionId));
+
+	return {
+		entries,
+		totalMissing: entries.length,
+		editionCount: uniqueEditions.size
+	};
+}
+
+/**
+ * Get missing copies for a season
+ * Uses season_works → season_work_editions instead of event_works
+ */
+export async function getMissingCopiesForSeason(
+	db: D1Database,
+	seasonId: string
+): Promise<MissingCopiesReport> {
+	const query = `
+		SELECT 
+			m.id as member_id,
+			m.name as member_name,
+			s.id as section_id,
+			s.name as section_name,
+			e.id as edition_id,
+			e.name as edition_name,
+			w.id as work_id,
+			w.title as work_title,
+			w.composer
+		FROM season_works sw
+		JOIN season_work_editions swe ON swe.season_work_id = sw.id
+		JOIN editions e ON e.id = swe.edition_id
+		JOIN works w ON w.id = e.work_id
+		JOIN edition_sections es ON es.edition_id = e.id
+		JOIN member_sections ms ON ms.section_id = es.section_id
+		JOIN members m ON m.id = ms.member_id
+		JOIN sections s ON s.id = ms.section_id
+		WHERE sw.season_id = ?
+			AND m.email_id IS NOT NULL
+			AND NOT EXISTS (
+				SELECT 1 
+				FROM physical_copies pc
+				JOIN copy_assignments ca ON ca.copy_id = pc.id
+				WHERE pc.edition_id = e.id
+					AND ca.member_id = m.id
+					AND ca.returned_at IS NULL
+			)
+		ORDER BY w.title, e.name, s.name, m.name
+	`;
+
+	const { results } = await db.prepare(query).bind(seasonId).all<MissingCopyRow>();
+
+	const entries: MissingCopyEntry[] = results.map((row) => ({
+		memberId: row.member_id,
+		memberName: row.member_name,
+		sectionId: row.section_id,
+		sectionName: row.section_name,
+		editionId: row.edition_id,
+		editionName: row.edition_name,
+		workId: row.work_id,
+		workTitle: row.work_title,
+		composer: row.composer
+	}));
+
+	const uniqueEditions = new Set(entries.map((e) => e.editionId));
+
+	return {
+		entries,
+		totalMissing: entries.length,
+		editionCount: uniqueEditions.size
+	};
+}

--- a/apps/vault/src/routes/library/inventory/+page.svelte
+++ b/apps/vault/src/routes/library/inventory/+page.svelte
@@ -19,14 +19,22 @@
 
 <div class="container mx-auto max-w-6xl px-4 py-8">
 	<!-- Header -->
-	<div class="mb-8">
-		<nav class="mb-4 text-sm text-gray-500">
-			<a href="/works" class="hover:text-blue-600">Library</a>
-			<span class="mx-2">›</span>
-			<span>Inventory</span>
-		</nav>
-		<h1 class="text-3xl font-bold">Inventory Reports</h1>
-		<p class="mt-2 text-gray-600">Physical copy inventory summary per edition</p>
+	<div class="mb-8 flex items-start justify-between">
+		<div>
+			<nav class="mb-4 text-sm text-gray-500">
+				<a href="/works" class="hover:text-blue-600">Library</a>
+				<span class="mx-2">›</span>
+				<span>Inventory</span>
+			</nav>
+			<h1 class="text-3xl font-bold">Inventory Reports</h1>
+			<p class="mt-2 text-gray-600">Physical copy inventory summary per edition</p>
+		</div>
+		<a
+			href="/library/reports/missing-copies"
+			class="rounded-lg bg-amber-600 px-4 py-2 text-white transition hover:bg-amber-700"
+		>
+			Missing Copies Report
+		</a>
 	</div>
 
 	<!-- Summary Stats -->

--- a/apps/vault/src/routes/library/reports/missing-copies/+page.server.ts
+++ b/apps/vault/src/routes/library/reports/missing-copies/+page.server.ts
@@ -1,0 +1,86 @@
+// Missing Copies Report page server loader
+// Issue #123: Report showing members who need copies but don't have them
+import { error, redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { getMemberById } from '$lib/server/db/members';
+import { canUploadScores } from '$lib/server/auth/permissions';
+import { getUpcomingEvents } from '$lib/server/db/events';
+import {
+	getMissingCopiesForEvent,
+	getMissingCopiesForSeason,
+	type MissingCopiesReport
+} from '$lib/server/db/inventory-reports';
+
+interface SeasonOption {
+	id: string;
+	name: string;
+}
+
+export const load: PageServerLoad = async ({ platform, cookies, url }) => {
+	if (!platform?.env?.DB) {
+		throw error(500, 'Database unavailable');
+	}
+
+	const db = platform.env.DB;
+	const memberId = cookies.get('member_id');
+
+	// Require authentication
+	if (!memberId) {
+		throw redirect(303, '/welcome');
+	}
+
+	// Get member and check permissions
+	const member = await getMemberById(db, memberId);
+	if (!member) {
+		throw redirect(303, '/welcome');
+	}
+
+	// Permission check: librarian/admin/owner only
+	if (!canUploadScores(member)) {
+		throw redirect(303, '/works');
+	}
+
+	// Load filter options
+	const events = await getUpcomingEvents(db);
+
+	// Load seasons (query directly - simple read)
+	const { results: seasonRows } = await db
+		.prepare('SELECT id, name FROM seasons ORDER BY start_date DESC')
+		.all<{ id: string; name: string }>();
+	const seasons: SeasonOption[] = seasonRows;
+
+	// Get filter params
+	const eventId = url.searchParams.get('event');
+	const seasonId = url.searchParams.get('season');
+
+	// Generate report based on filter
+	let report: MissingCopiesReport | null = null;
+	let filterType: 'event' | 'season' | null = null;
+	let filterName: string | null = null;
+
+	if (eventId) {
+		const selectedEvent = events.find((e) => e.id === eventId);
+		if (selectedEvent) {
+			report = await getMissingCopiesForEvent(db, eventId);
+			filterType = 'event';
+			filterName = selectedEvent.title;
+		}
+	} else if (seasonId) {
+		const selectedSeason = seasons.find((s) => s.id === seasonId);
+		if (selectedSeason) {
+			report = await getMissingCopiesForSeason(db, seasonId);
+			filterType = 'season';
+			filterName = selectedSeason.name;
+		}
+	}
+
+	return {
+		events,
+		seasons,
+		report,
+		filterType,
+		filterName,
+		selectedEventId: eventId,
+		selectedSeasonId: seasonId
+	};
+};

--- a/apps/vault/src/routes/library/reports/missing-copies/+page.svelte
+++ b/apps/vault/src/routes/library/reports/missing-copies/+page.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import Card from '$lib/components/Card.svelte';
+	import type { MissingCopyEntry } from '$lib/server/db/inventory-reports';
+
+	let { data }: { data: PageData } = $props();
+
+	// Group entries by edition for display
+	const entriesByEdition = $derived(() => {
+		if (!data.report) return new Map<string, { edition: EditionInfo; members: MemberInfo[] }>();
+
+		const grouped = new Map<string, { edition: EditionInfo; members: MemberInfo[] }>();
+
+		for (const entry of data.report.entries) {
+			if (!grouped.has(entry.editionId)) {
+				grouped.set(entry.editionId, {
+					edition: {
+						id: entry.editionId,
+						name: entry.editionName,
+						workId: entry.workId,
+						workTitle: entry.workTitle,
+						composer: entry.composer
+					},
+					members: []
+				});
+			}
+			grouped.get(entry.editionId)!.members.push({
+				id: entry.memberId,
+				name: entry.memberName,
+				sectionId: entry.sectionId,
+				sectionName: entry.sectionName
+			});
+		}
+
+		return grouped;
+	});
+
+	interface EditionInfo {
+		id: string;
+		name: string;
+		workId: string;
+		workTitle: string;
+		composer: string | null;
+	}
+
+	interface MemberInfo {
+		id: string;
+		name: string;
+		sectionId: string;
+		sectionName: string;
+	}
+</script>
+
+<svelte:head>
+	<title>Missing Copies Report | Polyphony Vault</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-6xl px-4 py-8">
+	<!-- Header -->
+	<div class="mb-8">
+		<nav class="mb-4 text-sm text-gray-500">
+			<a href="/works" class="hover:text-blue-600">Library</a>
+			<span class="mx-2">›</span>
+			<a href="/library/inventory" class="hover:text-blue-600">Inventory</a>
+			<span class="mx-2">›</span>
+			<span>Missing Copies</span>
+		</nav>
+		<h1 class="text-3xl font-bold">Missing Copies Report</h1>
+		<p class="mt-2 text-gray-600">Members who need copies but don't have them assigned</p>
+	</div>
+
+	<!-- Filters -->
+	<Card class="mb-6">
+		<div class="flex flex-wrap gap-4">
+			<!-- Event Filter -->
+			<div class="flex-1 min-w-[200px]">
+				<label for="event-filter" class="mb-1 block text-sm font-medium text-gray-700">
+					Filter by Event
+				</label>
+				<select
+					id="event-filter"
+					class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+					value={data.selectedEventId ?? ''}
+					onchange={(e) => {
+						const value = e.currentTarget.value;
+						if (value) {
+							window.location.href = `?event=${value}`;
+						} else {
+							window.location.href = window.location.pathname;
+						}
+					}}
+				>
+					<option value="">Select an event...</option>
+					{#each data.events as event}
+						<option value={event.id}>{event.title}</option>
+					{/each}
+				</select>
+			</div>
+
+			<!-- Season Filter -->
+			<div class="flex-1 min-w-[200px]">
+				<label for="season-filter" class="mb-1 block text-sm font-medium text-gray-700">
+					Filter by Season
+				</label>
+				<select
+					id="season-filter"
+					class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+					value={data.selectedSeasonId ?? ''}
+					onchange={(e) => {
+						const value = e.currentTarget.value;
+						if (value) {
+							window.location.href = `?season=${value}`;
+						} else {
+							window.location.href = window.location.pathname;
+						}
+					}}
+				>
+					<option value="">Select a season...</option>
+					{#each data.seasons as season}
+						<option value={season.id}>{season.name}</option>
+					{/each}
+				</select>
+			</div>
+		</div>
+	</Card>
+
+	<!-- No Filter Selected -->
+	{#if !data.report}
+		<Card>
+			<div class="py-12 text-center text-gray-500">
+				<svg class="mx-auto mb-4 h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+				</svg>
+				<p class="text-lg font-medium">Select an event or season to generate the report</p>
+				<p class="mt-2 text-sm">
+					The report shows which registered members in relevant sections don't have copies assigned.
+				</p>
+			</div>
+		</Card>
+	{:else if data.report.totalMissing === 0}
+		<!-- All Copies Assigned -->
+		<Card>
+			<div class="py-12 text-center">
+				<svg class="mx-auto mb-4 h-12 w-12 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+				</svg>
+				<p class="text-lg font-medium text-green-700">All members have their copies!</p>
+				<p class="mt-2 text-sm text-gray-500">
+					Every registered member in relevant sections for "{data.filterName}" has a copy assigned.
+				</p>
+			</div>
+		</Card>
+	{:else}
+		<!-- Summary Stats -->
+		<div class="mb-6 grid grid-cols-2 gap-4">
+			<Card>
+				<div class="text-center">
+					<div class="text-3xl font-bold text-amber-600">{data.report.totalMissing}</div>
+					<div class="text-sm text-gray-500">Missing Assignments</div>
+				</div>
+			</Card>
+			<Card>
+				<div class="text-center">
+					<div class="text-3xl font-bold text-gray-900">{data.report.editionCount}</div>
+					<div class="text-sm text-gray-500">Editions Affected</div>
+				</div>
+			</Card>
+		</div>
+
+		<!-- Active Filter Badge -->
+		<div class="mb-4 flex items-center gap-2">
+			<span class="text-sm text-gray-500">Showing results for:</span>
+			<span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800">
+				{data.filterType === 'event' ? '📅' : '📆'} {data.filterName}
+			</span>
+			<a
+				href={window.location.pathname}
+				class="ml-2 text-sm text-gray-500 hover:text-gray-700"
+			>
+				Clear
+			</a>
+		</div>
+
+		<!-- Grouped Results -->
+		{#each [...entriesByEdition().entries()] as [editionId, group]}
+			<Card class="mb-4">
+				<!-- Edition Header -->
+				<div class="mb-4 border-b pb-3">
+					<div class="flex items-start justify-between">
+						<div>
+							<a
+								href="/editions/{editionId}"
+								class="text-lg font-semibold text-blue-600 hover:underline"
+							>
+								{group.edition.name}
+							</a>
+							<div class="text-sm text-gray-600">
+								{group.edition.workTitle}
+								{#if group.edition.composer}
+									<span class="text-gray-400">by {group.edition.composer}</span>
+								{/if}
+							</div>
+						</div>
+						<span class="rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-800">
+							{group.members.length} missing
+						</span>
+					</div>
+				</div>
+
+				<!-- Members Table -->
+				<table class="w-full">
+					<thead>
+						<tr class="text-left text-sm font-medium text-gray-500">
+							<th class="pb-2">Member</th>
+							<th class="pb-2">Section</th>
+							<th class="pb-2 text-right">Action</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each group.members as member}
+							<tr class="border-t hover:bg-gray-50">
+								<td class="py-2 font-medium text-gray-900">{member.name}</td>
+								<td class="py-2 text-gray-600">{member.sectionName}</td>
+								<td class="py-2 text-right">
+									<a
+										href="/editions/{editionId}?assign={member.id}"
+										class="inline-flex items-center gap-1 rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700"
+									>
+										Assign Copy
+									</a>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</Card>
+		{/each}
+	{/if}
+</div>


### PR DESCRIPTION
## Summary

Adds the Missing Copies Report page showing which registered members in relevant sections don't have copies assigned for event/season repertoire.

### Changes

- **New query module** (`inventory-reports.ts`):
  - `getMissingCopiesForEvent()` - 8-table join using NOT EXISTS pattern
  - `getMissingCopiesForSeason()` - season variant

- **New page** (`/library/reports/missing-copies`):
  - Event and season filter dropdowns
  - Summary cards (missing count, edition count)
  - Results grouped by edition with member tables
  - "Assign Copy" action links
  - Permission: librarian/admin/owner only

- **Navigation**: Added report link from inventory page

### Query Optimization

Used `NOT EXISTS` subquery instead of `LEFT JOIN + NULL check` to:
- Avoid row multiplication from cartesian expansion
- Allow SQLite to short-circuit at first match
- Eliminate need for `DISTINCT`

### Testing

- 9 unit tests for query functions
- All 871 tests passing (789 vault + 62 registry + 20 shared)

Closes #123
Part of Epic #106 - Phase D: Reports & Insights