### PR TITLE
feat(vault): Add collection reminders (#126)

### DIFF
--- a/apps/vault/src/routes/api/assignments/bulk-return/+server.ts
+++ b/apps/vault/src/routes/api/assignments/bulk-return/+server.ts
@@ -1,0 +1,54 @@
+// Bulk return copies API
+// Issue #126 - Collection Reminders
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getMemberById } from '$lib/server/db/members';
+import { canUploadScores } from '$lib/server/auth/permissions';
+import { bulkReturnCopies } from '$lib/server/db/inventory-reports';
+
+export const POST: RequestHandler = async ({ request, platform, cookies }) => {
+	const db = platform?.env?.DB;
+	if (!db) {
+		return json({ error: 'Database unavailable' }, { status: 500 });
+	}
+
+	// Auth check
+	const memberId = cookies.get('member_id');
+	if (!memberId) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	// Permission check - must be librarian/admin/owner
+	const member = await getMemberById(db, memberId);
+	if (!canUploadScores(member)) {
+		return json({ error: 'Permission denied' }, { status: 403 });
+	}
+
+	// Parse request body
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Invalid JSON' }, { status: 400 });
+	}
+
+	// Validate assignmentIds
+	if (typeof body !== 'object' || body === null) {
+		return json({ error: 'Request body must be an object' }, { status: 400 });
+	}
+
+	const { assignmentIds } = body as { assignmentIds?: unknown };
+
+	if (!Array.isArray(assignmentIds)) {
+		return json({ error: 'assignmentIds must be an array' }, { status: 400 });
+	}
+
+	if (!assignmentIds.every((id) => typeof id === 'string')) {
+		return json({ error: 'All assignment IDs must be strings' }, { status: 400 });
+	}
+
+	// Perform bulk return
+	const count = await bulkReturnCopies(db, assignmentIds);
+
+	return json({ returned: count });
+};

--- a/apps/vault/src/routes/library/inventory/+page.svelte
+++ b/apps/vault/src/routes/library/inventory/+page.svelte
@@ -29,12 +29,20 @@
 			<h1 class="text-3xl font-bold">Inventory Reports</h1>
 			<p class="mt-2 text-gray-600">Physical copy inventory summary per edition</p>
 		</div>
-		<a
-			href="/library/reports/missing-copies"
-			class="rounded-lg bg-amber-600 px-4 py-2 text-white transition hover:bg-amber-700"
-		>
-			Missing Copies Report
-		</a>
+		<div class="flex gap-3">
+			<a
+				href="/library/reports/collection"
+				class="rounded-lg border border-amber-600 px-4 py-2 text-amber-600 transition hover:bg-amber-50"
+			>
+				Collection Reminders
+			</a>
+			<a
+				href="/library/reports/missing-copies"
+				class="rounded-lg bg-amber-600 px-4 py-2 text-white transition hover:bg-amber-700"
+			>
+				Missing Copies Report
+			</a>
+		</div>
 	</div>
 
 	<!-- Summary Stats -->

--- a/apps/vault/src/routes/library/reports/collection/+page.server.ts
+++ b/apps/vault/src/routes/library/reports/collection/+page.server.ts
@@ -1,0 +1,45 @@
+// Collection Reminders page server
+// Issue #126 - Outstanding copies that need to be collected after a season
+import type { PageServerLoad } from './$types';
+import { error, redirect } from '@sveltejs/kit';
+import { getMemberById } from '$lib/server/db/members';
+import { canUploadScores } from '$lib/server/auth/permissions';
+import { getOutstandingCopiesForSeason } from '$lib/server/db/inventory-reports';
+import { getAllSeasons } from '$lib/server/db/seasons';
+
+export const load: PageServerLoad = async ({ platform, cookies, url }) => {
+	const db = platform?.env?.DB;
+	if (!db) throw error(500, 'Database not available');
+
+	// Auth check
+	const memberId = cookies.get('member_id');
+	if (!memberId) throw redirect(302, '/');
+
+	// Permission check
+	const member = await getMemberById(db, memberId);
+	if (!canUploadScores(member)) throw redirect(302, '/');
+
+	// Get all seasons
+	const seasons = await getAllSeasons(db);
+
+	// Get selected season from query param, or default to most recent season
+	const seasonId = url.searchParams.get('season');
+	const selectedSeasonId = seasonId ?? seasons[0]?.id ?? null;
+
+	// Get outstanding copies for selected season
+	let outstandingByMember: Awaited<ReturnType<typeof getOutstandingCopiesForSeason>> = [];
+	if (selectedSeasonId) {
+		outstandingByMember = await getOutstandingCopiesForSeason(db, selectedSeasonId);
+	}
+
+	// Calculate total
+	const totalOutstanding = outstandingByMember.reduce((sum, m) => sum + m.copies.length, 0);
+
+	return {
+		seasons,
+		selectedSeasonId,
+		outstandingByMember,
+		totalOutstanding,
+		memberCount: outstandingByMember.length
+	};
+};

--- a/apps/vault/src/tests/routes/api/assignments/bulk-return.spec.ts
+++ b/apps/vault/src/tests/routes/api/assignments/bulk-return.spec.ts
@@ -1,0 +1,177 @@
+// Bulk return API tests
+// Issue #126 - Collection Reminders
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../../../../routes/api/assignments/bulk-return/+server';
+
+// Mock modules
+vi.mock('$lib/server/db/members', () => ({
+	getMemberById: vi.fn()
+}));
+
+vi.mock('$lib/server/auth/permissions', () => ({
+	canUploadScores: vi.fn()
+}));
+
+vi.mock('$lib/server/db/inventory-reports', () => ({
+	bulkReturnCopies: vi.fn()
+}));
+
+import { getMemberById } from '$lib/server/db/members';
+import { canUploadScores } from '$lib/server/auth/permissions';
+import { bulkReturnCopies } from '$lib/server/db/inventory-reports';
+
+const mockGetMemberById = vi.mocked(getMemberById);
+const mockCanUploadScores = vi.mocked(canUploadScores);
+const mockBulkReturnCopies = vi.mocked(bulkReturnCopies);
+
+interface BulkReturnResponse {
+	returned: number;
+}
+
+interface ErrorResponse {
+	error: string;
+}
+
+const mockMember = {
+	id: 'librarian-1',
+	name: 'Librarian User',
+	nickname: null,
+	email_id: 'librarian@example.com',
+	email_contact: null,
+	roles: ['librarian'] as ('owner' | 'admin' | 'librarian' | 'conductor' | 'section_leader')[],
+	voices: [],
+	sections: [],
+	invited_by: null,
+	joined_at: '2026-01-01T00:00:00.000Z'
+};
+
+function createMockEvent(
+	memberId: string | undefined,
+	body: unknown,
+	jsonError = false
+) {
+	const mockDb = {};
+	return {
+		params: {},
+		url: new URL('http://localhost/api/assignments/bulk-return'),
+		request: {
+			json: jsonError
+				? vi.fn().mockRejectedValue(new Error('Invalid JSON'))
+				: vi.fn().mockResolvedValue(body)
+		} as unknown as Request,
+		cookies: {
+			get: vi.fn().mockReturnValue(memberId),
+			set: vi.fn(),
+			delete: vi.fn(),
+			getAll: vi.fn(),
+			serialize: vi.fn()
+		},
+		platform: { env: { DB: mockDb } },
+		locals: {},
+		fetch: vi.fn(),
+		getClientAddress: vi.fn().mockReturnValue('127.0.0.1'),
+		route: { id: '/api/assignments/bulk-return' as const },
+		setHeaders: vi.fn(),
+		isDataRequest: false,
+		isSubRequest: false,
+		tracing: {},
+		isRemoteRequest: false
+	} as unknown as Parameters<typeof POST>[0];
+}
+
+describe('POST /api/assignments/bulk-return', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns 401 when not authenticated', async () => {
+		const event = createMockEvent(undefined, { assignmentIds: ['a'] });
+
+		const response = await POST(event);
+
+		expect(response.status).toBe(401);
+		const data = (await response.json()) as ErrorResponse;
+		expect(data.error).toBe('Unauthorized');
+	});
+
+	it('returns 403 when not librarian', async () => {
+		mockGetMemberById.mockResolvedValue({ ...mockMember, roles: [] });
+		mockCanUploadScores.mockReturnValue(false);
+
+		const event = createMockEvent('member-1', { assignmentIds: ['a'] });
+
+		const response = await POST(event);
+
+		expect(response.status).toBe(403);
+		const data = (await response.json()) as ErrorResponse;
+		expect(data.error).toBe('Permission denied');
+	});
+
+	it('returns 400 for invalid JSON', async () => {
+		mockGetMemberById.mockResolvedValue(mockMember);
+		mockCanUploadScores.mockReturnValue(true);
+
+		const event = createMockEvent('librarian-1', {}, true);
+
+		const response = await POST(event);
+
+		expect(response.status).toBe(400);
+		const data = (await response.json()) as ErrorResponse;
+		expect(data.error).toBe('Invalid JSON');
+	});
+
+	it('returns 400 when assignmentIds is not an array', async () => {
+		mockGetMemberById.mockResolvedValue(mockMember);
+		mockCanUploadScores.mockReturnValue(true);
+
+		const event = createMockEvent('librarian-1', { assignmentIds: 'not-an-array' });
+
+		const response = await POST(event);
+
+		expect(response.status).toBe(400);
+		const data = (await response.json()) as ErrorResponse;
+		expect(data.error).toBe('assignmentIds must be an array');
+	});
+
+	it('returns 400 when assignmentIds contains non-strings', async () => {
+		mockGetMemberById.mockResolvedValue(mockMember);
+		mockCanUploadScores.mockReturnValue(true);
+
+		const event = createMockEvent('librarian-1', { assignmentIds: ['a', 123, 'b'] });
+
+		const response = await POST(event);
+
+		expect(response.status).toBe(400);
+		const data = (await response.json()) as ErrorResponse;
+		expect(data.error).toBe('All assignment IDs must be strings');
+	});
+
+	it('calls bulkReturnCopies and returns count', async () => {
+		mockGetMemberById.mockResolvedValue(mockMember);
+		mockCanUploadScores.mockReturnValue(true);
+		mockBulkReturnCopies.mockResolvedValue(3);
+
+		const event = createMockEvent('librarian-1', { assignmentIds: ['a', 'b', 'c'] });
+
+		const response = await POST(event);
+
+		expect(response.status).toBe(200);
+		const data = (await response.json()) as BulkReturnResponse;
+		expect(data.returned).toBe(3);
+		expect(mockBulkReturnCopies).toHaveBeenCalledWith({}, ['a', 'b', 'c']);
+	});
+
+	it('handles empty array', async () => {
+		mockGetMemberById.mockResolvedValue(mockMember);
+		mockCanUploadScores.mockReturnValue(true);
+		mockBulkReturnCopies.mockResolvedValue(0);
+
+		const event = createMockEvent('librarian-1', { assignmentIds: [] });
+
+		const response = await POST(event);
+
+		expect(response.status).toBe(200);
+		const data = (await response.json()) as BulkReturnResponse;
+		expect(data.returned).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
After a season ends, show librarian all outstanding copies that need to be collected.

### Changes
- `getOutstandingCopiesForSeason(seasonId)` - 7-table JOIN, grouped by member
- `bulkReturnCopies(assignmentIds)` - batch update for efficient collection
- `/api/assignments/bulk-return` endpoint
- `/library/reports/collection` page with:
  - Season selector dropdown
  - Member-grouped outstanding copies
  - Checkbox selection + bulk return action
- Navigation link from inventory page

### Testing
- 8 unit tests for query functions
- 7 API tests for bulk-return endpoint
- All 814 vault tests passing

Closes #126
Part of Epic #106 - Phase D: Reports & Insights