### PR TITLE
feat(vault): add organizations table for multi-org support

### DIFF
--- a/apps/vault/migrations/0025_organizations.sql
+++ b/apps/vault/migrations/0025_organizations.sql
@@ -1,0 +1,29 @@
+-- Migration 0025: Add organizations table (Schema V2)
+-- Part of Epic #158: Multi-Organization Implementation
+-- Issue #159: Add organizations table migration
+
+-- Organizations table: Core entity for multi-org support
+-- - umbrella: Organization that contains other organizations (e.g., Estonian Choral Association)
+-- - collective: Regular choir (most common, e.g., Kammerkoor Crede)
+CREATE TABLE IF NOT EXISTS organizations (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    subdomain TEXT NOT NULL UNIQUE,
+    type TEXT NOT NULL CHECK (type IN ('umbrella', 'collective')),
+    contact_email TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Index for subdomain lookups (used in routing)
+CREATE INDEX IF NOT EXISTS idx_organizations_subdomain ON organizations(subdomain);
+
+-- Seed Kammerkoor Crede as the first organization
+-- ID is a fixed UUID for migration reproducibility
+INSERT OR IGNORE INTO organizations (id, name, subdomain, type, contact_email)
+VALUES (
+    'org_crede_001',
+    'Kammerkoor Crede',
+    'crede',
+    'collective',
+    'info@crede.ee'
+);

--- a/apps/vault/src/lib/server/db/organizations.spec.ts
+++ b/apps/vault/src/lib/server/db/organizations.spec.ts
@@ -1,0 +1,272 @@
+// organizations.ts TDD test suite
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	createOrganization,
+	getOrganizationById,
+	getOrganizationBySubdomain,
+	getAllOrganizations,
+	updateOrganization
+} from './organizations';
+import type { Organization, OrganizationType, CreateOrganizationInput } from '$lib/types';
+
+// Mock D1Database for testing
+function createMockDB(): D1Database {
+	const organizations = new Map<string, any>();
+
+	return {
+		prepare: (sql: string) => {
+			return {
+				bind: (...params: any[]) => ({
+					first: async () => {
+						if (sql.includes('WHERE id = ?')) {
+							return organizations.get(params[0]) || null;
+						}
+						if (sql.includes('WHERE subdomain = ?')) {
+							for (const org of organizations.values()) {
+								if (org.subdomain === params[0]) {
+									return org;
+								}
+							}
+							return null;
+						}
+						return null;
+					},
+					all: async () => {
+						return { results: Array.from(organizations.values()) };
+					},
+					run: async () => {
+						if (sql.includes('INSERT INTO organizations')) {
+							const [id, name, subdomain, type, contactEmail] = params;
+							organizations.set(id, {
+								id,
+								name,
+								subdomain,
+								type,
+								contact_email: contactEmail,
+								created_at: new Date().toISOString()
+							});
+							return { success: true, meta: { changes: 1 } };
+						}
+						if (sql.includes('UPDATE organizations SET')) {
+							const id = params[params.length - 1]; // Last param is id
+							const org = organizations.get(id);
+							if (org) {
+								// Parse which fields are being updated
+								if (sql.includes('name = ?')) {
+									org.name = params[0];
+								}
+								if (sql.includes('contact_email = ?')) {
+									const idx = sql.includes('name = ?') ? 1 : 0;
+									org.contact_email = params[idx];
+								}
+								return { success: true, meta: { changes: 1 } };
+							}
+							return { success: false, meta: { changes: 0 } };
+						}
+						return { success: false, meta: { changes: 0 } };
+					}
+				}),
+				all: async () => {
+					return { results: Array.from(organizations.values()) };
+				}
+			};
+		},
+		batch: async () => ({ results: [] }),
+		exec: async () => ({ results: [] }),
+		dump: async () => new ArrayBuffer(0)
+	} as unknown as D1Database;
+}
+
+describe('Organizations Database Operations', () => {
+	let db: D1Database;
+
+	beforeEach(() => {
+		db = createMockDB();
+	});
+
+	describe('createOrganization', () => {
+		it('creates a collective organization', async () => {
+			const input: CreateOrganizationInput = {
+				name: 'Kammerkoor Crede',
+				subdomain: 'crede',
+				type: 'collective',
+				contactEmail: 'info@crede.ee'
+			};
+
+			const org = await createOrganization(db, input);
+
+			expect(org).toBeDefined();
+			expect(org.id).toBeDefined();
+			expect(org.name).toBe('Kammerkoor Crede');
+			expect(org.subdomain).toBe('crede');
+			expect(org.type).toBe('collective');
+			expect(org.contactEmail).toBe('info@crede.ee');
+			expect(org.createdAt).toBeDefined();
+		});
+
+		it('creates an umbrella organization', async () => {
+			const input: CreateOrganizationInput = {
+				name: 'Estonian Choral Association',
+				subdomain: 'eca',
+				type: 'umbrella',
+				contactEmail: 'contact@eca.ee'
+			};
+
+			const org = await createOrganization(db, input);
+
+			expect(org).toBeDefined();
+			expect(org.type).toBe('umbrella');
+		});
+
+		it('generates a unique ID', async () => {
+			const input1: CreateOrganizationInput = {
+				name: 'Org 1',
+				subdomain: 'org1',
+				type: 'collective',
+				contactEmail: 'org1@test.com'
+			};
+			const input2: CreateOrganizationInput = {
+				name: 'Org 2',
+				subdomain: 'org2',
+				type: 'collective',
+				contactEmail: 'org2@test.com'
+			};
+
+			const org1 = await createOrganization(db, input1);
+			const org2 = await createOrganization(db, input2);
+
+			expect(org1.id).not.toBe(org2.id);
+		});
+	});
+
+	describe('getOrganizationById', () => {
+		it('returns organization by ID', async () => {
+			const input: CreateOrganizationInput = {
+				name: 'Test Choir',
+				subdomain: 'test',
+				type: 'collective',
+				contactEmail: 'test@test.com'
+			};
+			const created = await createOrganization(db, input);
+
+			const fetched = await getOrganizationById(db, created.id);
+
+			expect(fetched).toBeDefined();
+			expect(fetched?.id).toBe(created.id);
+			expect(fetched?.name).toBe('Test Choir');
+		});
+
+		it('returns null for non-existent ID', async () => {
+			const result = await getOrganizationById(db, 'non-existent-id');
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('getOrganizationBySubdomain', () => {
+		it('returns organization by subdomain', async () => {
+			const input: CreateOrganizationInput = {
+				name: 'Tallinn Choir',
+				subdomain: 'tallinn',
+				type: 'collective',
+				contactEmail: 'info@tallinn-choir.ee'
+			};
+			await createOrganization(db, input);
+
+			const fetched = await getOrganizationBySubdomain(db, 'tallinn');
+
+			expect(fetched).toBeDefined();
+			expect(fetched?.subdomain).toBe('tallinn');
+			expect(fetched?.name).toBe('Tallinn Choir');
+		});
+
+		it('returns null for non-existent subdomain', async () => {
+			const result = await getOrganizationBySubdomain(db, 'unknown');
+
+			expect(result).toBeNull();
+		});
+
+		it('is case-sensitive for subdomain lookup', async () => {
+			const input: CreateOrganizationInput = {
+				name: 'Test',
+				subdomain: 'myorg',
+				type: 'collective',
+				contactEmail: 'test@test.com'
+			};
+			await createOrganization(db, input);
+
+			// Subdomains should be stored lowercase, lookup should match exactly
+			const fetched = await getOrganizationBySubdomain(db, 'myorg');
+			expect(fetched).toBeDefined();
+		});
+	});
+
+	describe('getAllOrganizations', () => {
+		it('returns empty array when no organizations exist', async () => {
+			const orgs = await getAllOrganizations(db);
+
+			expect(orgs).toEqual([]);
+		});
+
+		it('returns all organizations', async () => {
+			await createOrganization(db, {
+				name: 'Org 1',
+				subdomain: 'org1',
+				type: 'collective',
+				contactEmail: 'org1@test.com'
+			});
+			await createOrganization(db, {
+				name: 'Org 2',
+				subdomain: 'org2',
+				type: 'umbrella',
+				contactEmail: 'org2@test.com'
+			});
+
+			const orgs = await getAllOrganizations(db);
+
+			expect(orgs).toHaveLength(2);
+		});
+	});
+
+	describe('updateOrganization', () => {
+		it('updates organization name', async () => {
+			const created = await createOrganization(db, {
+				name: 'Old Name',
+				subdomain: 'test',
+				type: 'collective',
+				contactEmail: 'test@test.com'
+			});
+
+			const updated = await updateOrganization(db, created.id, {
+				name: 'New Name'
+			});
+
+			expect(updated).toBeDefined();
+			expect(updated?.name).toBe('New Name');
+		});
+
+		it('updates contact email', async () => {
+			const created = await createOrganization(db, {
+				name: 'Test',
+				subdomain: 'test',
+				type: 'collective',
+				contactEmail: 'old@test.com'
+			});
+
+			const updated = await updateOrganization(db, created.id, {
+				contactEmail: 'new@test.com'
+			});
+
+			expect(updated).toBeDefined();
+			expect(updated?.contactEmail).toBe('new@test.com');
+		});
+
+		it('returns null for non-existent organization', async () => {
+			const result = await updateOrganization(db, 'non-existent', {
+				name: 'New Name'
+			});
+
+			expect(result).toBeNull();
+		});
+	});
+});

--- a/apps/vault/src/lib/server/db/organizations.ts
+++ b/apps/vault/src/lib/server/db/organizations.ts
@@ -1,0 +1,150 @@
+// Organization database operations
+// Part of Schema V2 multi-organization support
+
+import type { Organization, CreateOrganizationInput, UpdateOrganizationInput } from '$lib/types';
+
+// Simple ID generator (consistent with members.ts pattern)
+function generateId(): string {
+	return 'org_' + crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+}
+
+/**
+ * Create a new organization
+ */
+export async function createOrganization(
+	db: D1Database,
+	input: CreateOrganizationInput
+): Promise<Organization> {
+	const id = generateId();
+	const now = new Date().toISOString();
+
+	await db
+		.prepare(
+			'INSERT INTO organizations (id, name, subdomain, type, contact_email, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+		)
+		.bind(id, input.name, input.subdomain.toLowerCase(), input.type, input.contactEmail, now)
+		.run();
+
+	return {
+		id,
+		name: input.name,
+		subdomain: input.subdomain.toLowerCase(),
+		type: input.type,
+		contactEmail: input.contactEmail,
+		createdAt: now
+	};
+}
+
+/**
+ * Get organization by ID
+ */
+export async function getOrganizationById(
+	db: D1Database,
+	id: string
+): Promise<Organization | null> {
+	const row = await db
+		.prepare('SELECT id, name, subdomain, type, contact_email, created_at FROM organizations WHERE id = ?')
+		.bind(id)
+		.first<OrganizationRow>();
+
+	if (!row) {
+		return null;
+	}
+
+	return mapRowToOrganization(row);
+}
+
+/**
+ * Get organization by subdomain (used in routing)
+ */
+export async function getOrganizationBySubdomain(
+	db: D1Database,
+	subdomain: string
+): Promise<Organization | null> {
+	const row = await db
+		.prepare('SELECT id, name, subdomain, type, contact_email, created_at FROM organizations WHERE subdomain = ?')
+		.bind(subdomain.toLowerCase())
+		.first<OrganizationRow>();
+
+	if (!row) {
+		return null;
+	}
+
+	return mapRowToOrganization(row);
+}
+
+/**
+ * Get all organizations
+ */
+export async function getAllOrganizations(db: D1Database): Promise<Organization[]> {
+	const { results } = await db
+		.prepare('SELECT id, name, subdomain, type, contact_email, created_at FROM organizations ORDER BY name')
+		.all<OrganizationRow>();
+
+	return results.map(mapRowToOrganization);
+}
+
+/**
+ * Update organization (name and/or contact email only - subdomain and type are immutable)
+ */
+export async function updateOrganization(
+	db: D1Database,
+	id: string,
+	input: UpdateOrganizationInput
+): Promise<Organization | null> {
+	// Build dynamic UPDATE statement based on provided fields
+	const updates: string[] = [];
+	const params: (string | null)[] = [];
+
+	if (input.name !== undefined) {
+		updates.push('name = ?');
+		params.push(input.name);
+	}
+
+	if (input.contactEmail !== undefined) {
+		updates.push('contact_email = ?');
+		params.push(input.contactEmail);
+	}
+
+	if (updates.length === 0) {
+		// Nothing to update, just return existing organization
+		return getOrganizationById(db, id);
+	}
+
+	params.push(id); // WHERE clause parameter
+
+	const result = await db
+		.prepare(`UPDATE organizations SET ${updates.join(', ')} WHERE id = ?`)
+		.bind(...params)
+		.run();
+
+	if ((result.meta.changes ?? 0) === 0) {
+		return null;
+	}
+
+	return getOrganizationById(db, id);
+}
+
+// =============================================================================
+// Internal types and helpers
+// =============================================================================
+
+interface OrganizationRow {
+	id: string;
+	name: string;
+	subdomain: string;
+	type: 'umbrella' | 'collective';
+	contact_email: string;
+	created_at: string;
+}
+
+function mapRowToOrganization(row: OrganizationRow): Organization {
+	return {
+		id: row.id,
+		name: row.name,
+		subdomain: row.subdomain,
+		type: row.type,
+		contactEmail: row.contact_email,
+		createdAt: row.created_at
+	};
+}

--- a/apps/vault/src/lib/types.ts
+++ b/apps/vault/src/lib/types.ts
@@ -9,6 +9,44 @@ export const ASSIGNABLE_ROLES = ['owner', 'admin', 'librarian', 'conductor', 'se
 export type EventType = 'rehearsal' | 'concert' | 'retreat';
 
 // ============================================================================
+// ORGANIZATIONS SYSTEM (Schema V2)
+// ============================================================================
+
+export type OrganizationType = 'umbrella' | 'collective';
+
+/**
+ * Organization: A choir or umbrella entity
+ * - collective: Regular choir (most common)
+ * - umbrella: Organization that contains other organizations
+ */
+export interface Organization {
+	id: string;
+	name: string;
+	subdomain: string;
+	type: OrganizationType;
+	contactEmail: string;
+	createdAt: string;
+}
+
+/**
+ * Input for creating a new organization
+ */
+export interface CreateOrganizationInput {
+	name: string;
+	subdomain: string;
+	type: OrganizationType;
+	contactEmail: string;
+}
+
+/**
+ * Input for updating an organization
+ */
+export interface UpdateOrganizationInput {
+	name?: string;
+	contactEmail?: string;
+}
+
+// ============================================================================
 // VOICES & SECTIONS SYSTEM
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Schema V2 Phase 0.5 - Organizations table implementation.

### Changes

- **Migration** `0025_organizations.sql`: Creates `organizations` table with subdomain routing index
- **Types** in `types.ts`: `Organization`, `OrganizationType`, `CreateOrganizationInput`, `UpdateOrganizationInput`
- **CRUD operations** in `organizations.ts`: `createOrganization`, `getOrganizationById`, `getOrganizationBySubdomain`, `getAllOrganizations`, `updateOrganization`
- **Test suite**: 13 comprehensive tests

### Schema

```sql
CREATE TABLE organizations (
    id TEXT PRIMARY KEY,
    name TEXT NOT NULL,
    subdomain TEXT NOT NULL UNIQUE,
    type TEXT NOT NULL CHECK (type IN ('umbrella', 'collective')),
    contact_email TEXT NOT NULL,
    created_at TEXT NOT NULL DEFAULT (datetime('now'))
);
```

Seeds Kammerkoor Crede as the first organization.

## Testing

- ✅ 13 new tests pass
- ✅ All 827 vault tests pass
- ✅ Type checks clean

## Part of

- Epic #158: Schema V2 Multi-Organization Implementation
- Closes #159

## Next Steps

This unblocks:
- #160 member_organizations junction table
- #161 org_id on member_roles
- #162 org_id on sections