### PR TITLE
feat(vault): add member_organizations junction table

### DIFF
--- a/apps/vault/migrations/0026_member_organizations.sql
+++ b/apps/vault/migrations/0026_member_organizations.sql
@@ -1,0 +1,24 @@
+-- Migration 0026: Add member_organizations junction table (Schema V2)
+-- Part of Epic #158: Multi-Organization Implementation
+-- Issue #160: Add member_organizations junction table
+
+-- Junction table linking members to organizations with org-specific data
+CREATE TABLE IF NOT EXISTS member_organizations (
+    member_id TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+    org_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    nickname TEXT,                     -- org-specific display name (optional)
+    invited_by TEXT REFERENCES members(id) ON DELETE SET NULL,
+    joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (member_id, org_id)
+);
+
+-- Index for efficient org member lookups
+CREATE INDEX IF NOT EXISTS idx_member_orgs_org ON member_organizations(org_id);
+
+-- Index for efficient member org lookups
+CREATE INDEX IF NOT EXISTS idx_member_orgs_member ON member_organizations(member_id);
+
+-- Migrate existing members to Crede organization
+-- Uses org_crede_001 from migration 0025
+INSERT INTO member_organizations (member_id, org_id, nickname, invited_by, joined_at)
+SELECT id, 'org_crede_001', nickname, invited_by, joined_at FROM members;

--- a/apps/vault/src/lib/server/db/member-organizations.spec.ts
+++ b/apps/vault/src/lib/server/db/member-organizations.spec.ts
@@ -1,0 +1,231 @@
+// member-organizations.ts TDD test suite
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	addMemberToOrganization,
+	getMemberOrganizations,
+	getMembersByOrganization,
+	removeMemberFromOrganization,
+	updateMemberOrgNickname
+} from './member-organizations';
+import type { MemberOrganization, AddMemberToOrgInput } from '$lib/types';
+
+// Mock D1Database for testing
+function createMockDB(): D1Database {
+	const memberOrgs = new Map<string, any>(); // key: `${memberId}:${orgId}`
+
+	return {
+		prepare: (sql: string) => {
+			return {
+				bind: (...params: any[]) => ({
+					first: async () => {
+						if (sql.includes('WHERE member_id = ? AND org_id = ?')) {
+							const key = `${params[0]}:${params[1]}`;
+							return memberOrgs.get(key) || null;
+						}
+						return null;
+					},
+					all: async () => {
+						if (sql.includes('WHERE member_id = ?')) {
+							const memberId = params[0];
+							const results = Array.from(memberOrgs.values()).filter(
+								(mo) => mo.member_id === memberId
+							);
+							return { results };
+						}
+						if (sql.includes('WHERE org_id = ?')) {
+							const orgId = params[0];
+							const results = Array.from(memberOrgs.values()).filter(
+								(mo) => mo.org_id === orgId
+							);
+							return { results };
+						}
+						return { results: [] };
+					},
+					run: async () => {
+						if (sql.includes('INSERT INTO member_organizations')) {
+							const [memberId, orgId, nickname, invitedBy] = params;
+							const key = `${memberId}:${orgId}`;
+							memberOrgs.set(key, {
+								member_id: memberId,
+								org_id: orgId,
+								nickname: nickname || null,
+								invited_by: invitedBy || null,
+								joined_at: new Date().toISOString()
+							});
+							return { success: true, meta: { changes: 1 } };
+						}
+						if (sql.includes('UPDATE member_organizations SET nickname')) {
+							const [nickname, memberId, orgId] = params;
+							const key = `${memberId}:${orgId}`;
+							const mo = memberOrgs.get(key);
+							if (mo) {
+								mo.nickname = nickname;
+								return { success: true, meta: { changes: 1 } };
+							}
+							return { success: false, meta: { changes: 0 } };
+						}
+						if (sql.includes('DELETE FROM member_organizations')) {
+							const [memberId, orgId] = params;
+							const key = `${memberId}:${orgId}`;
+							const deleted = memberOrgs.delete(key);
+							return { success: deleted, meta: { changes: deleted ? 1 : 0 } };
+						}
+						return { success: false, meta: { changes: 0 } };
+					}
+				}),
+				all: async () => ({ results: [] })
+			};
+		},
+		batch: async () => ({ results: [] }),
+		exec: async () => ({ results: [] }),
+		dump: async () => new ArrayBuffer(0)
+	} as unknown as D1Database;
+}
+
+describe('Member Organizations Database Operations', () => {
+	let db: D1Database;
+
+	beforeEach(() => {
+		db = createMockDB();
+	});
+
+	describe('addMemberToOrganization', () => {
+		it('adds a member to an organization', async () => {
+			const input: AddMemberToOrgInput = {
+				memberId: 'member_001',
+				orgId: 'org_crede_001'
+			};
+
+			const result = await addMemberToOrganization(db, input);
+
+			expect(result).toBeDefined();
+			expect(result.memberId).toBe('member_001');
+			expect(result.orgId).toBe('org_crede_001');
+			expect(result.nickname).toBeNull();
+			expect(result.invitedBy).toBeNull();
+			expect(result.joinedAt).toBeDefined();
+		});
+
+		it('adds a member with nickname and invitedBy', async () => {
+			const input: AddMemberToOrgInput = {
+				memberId: 'member_002',
+				orgId: 'org_crede_001',
+				nickname: 'Tom',
+				invitedBy: 'member_001'
+			};
+
+			const result = await addMemberToOrganization(db, input);
+
+			expect(result.nickname).toBe('Tom');
+			expect(result.invitedBy).toBe('member_001');
+		});
+	});
+
+	describe('getMemberOrganizations', () => {
+		it('returns all organizations for a member', async () => {
+			// Add member to two orgs
+			await addMemberToOrganization(db, {
+				memberId: 'member_001',
+				orgId: 'org_crede_001'
+			});
+			await addMemberToOrganization(db, {
+				memberId: 'member_001',
+				orgId: 'org_eca_001'
+			});
+
+			const orgs = await getMemberOrganizations(db, 'member_001');
+
+			expect(orgs).toHaveLength(2);
+		});
+
+		it('returns empty array for member with no organizations', async () => {
+			const orgs = await getMemberOrganizations(db, 'nonexistent');
+
+			expect(orgs).toEqual([]);
+		});
+	});
+
+	describe('getMembersByOrganization', () => {
+		it('returns all members in an organization', async () => {
+			await addMemberToOrganization(db, {
+				memberId: 'member_001',
+				orgId: 'org_crede_001'
+			});
+			await addMemberToOrganization(db, {
+				memberId: 'member_002',
+				orgId: 'org_crede_001'
+			});
+			await addMemberToOrganization(db, {
+				memberId: 'member_003',
+				orgId: 'org_other_001' // Different org
+			});
+
+			const members = await getMembersByOrganization(db, 'org_crede_001');
+
+			expect(members).toHaveLength(2);
+			expect(members.map((m) => m.memberId)).toContain('member_001');
+			expect(members.map((m) => m.memberId)).toContain('member_002');
+		});
+
+		it('returns empty array for organization with no members', async () => {
+			const members = await getMembersByOrganization(db, 'empty_org');
+
+			expect(members).toEqual([]);
+		});
+	});
+
+	describe('removeMemberFromOrganization', () => {
+		it('removes a member from an organization', async () => {
+			await addMemberToOrganization(db, {
+				memberId: 'member_001',
+				orgId: 'org_crede_001'
+			});
+
+			const removed = await removeMemberFromOrganization(db, 'member_001', 'org_crede_001');
+
+			expect(removed).toBe(true);
+
+			const orgs = await getMemberOrganizations(db, 'member_001');
+			expect(orgs).toHaveLength(0);
+		});
+
+		it('returns false when removing non-existent membership', async () => {
+			const removed = await removeMemberFromOrganization(db, 'nonexistent', 'org_crede_001');
+
+			expect(removed).toBe(false);
+		});
+	});
+
+	describe('updateMemberOrgNickname', () => {
+		it('updates nickname for a member in an organization', async () => {
+			await addMemberToOrganization(db, {
+				memberId: 'member_001',
+				orgId: 'org_crede_001'
+			});
+
+			const updated = await updateMemberOrgNickname(db, 'member_001', 'org_crede_001', 'Tommy');
+
+			expect(updated).toBeDefined();
+			expect(updated?.nickname).toBe('Tommy');
+		});
+
+		it('returns null for non-existent membership', async () => {
+			const updated = await updateMemberOrgNickname(db, 'nonexistent', 'org_crede_001', 'Nick');
+
+			expect(updated).toBeNull();
+		});
+
+		it('clears nickname when set to null', async () => {
+			await addMemberToOrganization(db, {
+				memberId: 'member_001',
+				orgId: 'org_crede_001',
+				nickname: 'Tom'
+			});
+
+			const updated = await updateMemberOrgNickname(db, 'member_001', 'org_crede_001', null);
+
+			expect(updated).toBeDefined();
+			expect(updated?.nickname).toBeNull();
+		});
+	});
+});

--- a/apps/vault/src/lib/server/db/member-organizations.ts
+++ b/apps/vault/src/lib/server/db/member-organizations.ts
@@ -1,0 +1,152 @@
+// Member-Organization junction table operations
+// Part of Schema V2 multi-organization support
+
+import type { MemberOrganization, AddMemberToOrgInput } from '$lib/types';
+
+/**
+ * Add a member to an organization
+ */
+export async function addMemberToOrganization(
+	db: D1Database,
+	input: AddMemberToOrgInput
+): Promise<MemberOrganization> {
+	const now = new Date().toISOString();
+
+	await db
+		.prepare(
+			'INSERT INTO member_organizations (member_id, org_id, nickname, invited_by, joined_at) VALUES (?, ?, ?, ?, ?)'
+		)
+		.bind(
+			input.memberId,
+			input.orgId,
+			input.nickname ?? null,
+			input.invitedBy ?? null,
+			now
+		)
+		.run();
+
+	return {
+		memberId: input.memberId,
+		orgId: input.orgId,
+		nickname: input.nickname ?? null,
+		invitedBy: input.invitedBy ?? null,
+		joinedAt: now
+	};
+}
+
+/**
+ * Get all organizations a member belongs to
+ */
+export async function getMemberOrganizations(
+	db: D1Database,
+	memberId: string
+): Promise<MemberOrganization[]> {
+	const { results } = await db
+		.prepare(
+			'SELECT member_id, org_id, nickname, invited_by, joined_at FROM member_organizations WHERE member_id = ?'
+		)
+		.bind(memberId)
+		.all<MemberOrganizationRow>();
+
+	return results.map(mapRowToMemberOrganization);
+}
+
+/**
+ * Get all members in an organization
+ */
+export async function getMembersByOrganization(
+	db: D1Database,
+	orgId: string
+): Promise<MemberOrganization[]> {
+	const { results } = await db
+		.prepare(
+			'SELECT member_id, org_id, nickname, invited_by, joined_at FROM member_organizations WHERE org_id = ?'
+		)
+		.bind(orgId)
+		.all<MemberOrganizationRow>();
+
+	return results.map(mapRowToMemberOrganization);
+}
+
+/**
+ * Get a specific member-organization relationship
+ */
+export async function getMemberOrganization(
+	db: D1Database,
+	memberId: string,
+	orgId: string
+): Promise<MemberOrganization | null> {
+	const row = await db
+		.prepare(
+			'SELECT member_id, org_id, nickname, invited_by, joined_at FROM member_organizations WHERE member_id = ? AND org_id = ?'
+		)
+		.bind(memberId, orgId)
+		.first<MemberOrganizationRow>();
+
+	if (!row) {
+		return null;
+	}
+
+	return mapRowToMemberOrganization(row);
+}
+
+/**
+ * Remove a member from an organization
+ */
+export async function removeMemberFromOrganization(
+	db: D1Database,
+	memberId: string,
+	orgId: string
+): Promise<boolean> {
+	const result = await db
+		.prepare('DELETE FROM member_organizations WHERE member_id = ? AND org_id = ?')
+		.bind(memberId, orgId)
+		.run();
+
+	return (result.meta.changes ?? 0) > 0;
+}
+
+/**
+ * Update a member's nickname in an organization
+ */
+export async function updateMemberOrgNickname(
+	db: D1Database,
+	memberId: string,
+	orgId: string,
+	nickname: string | null
+): Promise<MemberOrganization | null> {
+	const result = await db
+		.prepare(
+			'UPDATE member_organizations SET nickname = ? WHERE member_id = ? AND org_id = ?'
+		)
+		.bind(nickname, memberId, orgId)
+		.run();
+
+	if ((result.meta.changes ?? 0) === 0) {
+		return null;
+	}
+
+	return getMemberOrganization(db, memberId, orgId);
+}
+
+// =============================================================================
+// Internal types and helpers
+// =============================================================================
+
+interface MemberOrganizationRow {
+	member_id: string;
+	org_id: string;
+	nickname: string | null;
+	invited_by: string | null;
+	joined_at: string;
+}
+
+function mapRowToMemberOrganization(row: MemberOrganizationRow): MemberOrganization {
+	return {
+		memberId: row.member_id,
+		orgId: row.org_id,
+		nickname: row.nickname,
+		invitedBy: row.invited_by,
+		joinedAt: row.joined_at
+	};
+}

--- a/apps/vault/src/lib/types.ts
+++ b/apps/vault/src/lib/types.ts
@@ -47,6 +47,32 @@ export interface UpdateOrganizationInput {
 }
 
 // ============================================================================
+// MEMBER ORGANIZATIONS SYSTEM (Schema V2)
+// ============================================================================
+
+/**
+ * Member-Organization relationship (junction table)
+ * Links a global member identity to an organization with org-specific data
+ */
+export interface MemberOrganization {
+	memberId: string;
+	orgId: string;
+	nickname: string | null; // Org-specific display name
+	invitedBy: string | null;
+	joinedAt: string;
+}
+
+/**
+ * Input for adding a member to an organization
+ */
+export interface AddMemberToOrgInput {
+	memberId: string;
+	orgId: string;
+	nickname?: string;
+	invitedBy?: string;
+}
+
+// ============================================================================
 // VOICES & SECTIONS SYSTEM
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Schema V2 Phase 0.5 - Member-Organization junction table for multi-org support.

### Changes

- **Migration** `0026_member_organizations.sql`: Creates junction table + migrates existing members to Crede
- **Types** in `types.ts`: `MemberOrganization`, `AddMemberToOrgInput`
- **CRUD operations** in `member-organizations.ts`:
  - `addMemberToOrganization()`
  - `getMemberOrganizations()`
  - `getMembersByOrganization()`
  - `getMemberOrganization()`
  - `removeMemberFromOrganization()`
  - `updateMemberOrgNickname()`
- **Test suite**: 11 comprehensive tests

### Schema

```sql
CREATE TABLE member_organizations (
    member_id TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
    org_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
    nickname TEXT,
    invited_by TEXT REFERENCES members(id) ON DELETE SET NULL,
    joined_at TEXT NOT NULL DEFAULT (datetime('now')),
    PRIMARY KEY (member_id, org_id)
);
```

### Data Migration

All existing members are automatically added to the Crede organization (`org_crede_001`) with their existing `nickname`, `invited_by`, and `joined_at` values.

## Testing

- ✅ 11 new tests pass
- ✅ All 838 vault tests pass (up from 827)
- ✅ Type checks clean

## Part of

- Epic #158: Schema V2 Multi-Organization Implementation
- Closes #160

## Unblocks

- #161 org_id on member_roles
- #165 subdomain routing (partially)