### PR TITLE
feat(vault): Add org_id to sections table (#162)

### DIFF
--- a/apps/vault/migrations/0028_sections_org_id.sql
+++ b/apps/vault/migrations/0028_sections_org_id.sql
@@ -1,0 +1,32 @@
+-- Migration 0028: Add org_id to sections (Schema V2)
+-- Part of Epic #158: Multi-Organization Implementation
+-- Issue #162: Add org_id to sections table
+
+-- Sections are per-organization (Choir A's "T1" ≠ Choir B's "T1")
+-- Voices remain global (a singer's vocal capability is intrinsic)
+
+-- Step 1: Create new table with org_id
+CREATE TABLE sections_new (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    abbreviation TEXT NOT NULL,
+    parent_section_id TEXT REFERENCES sections_new(id),
+    display_order INTEGER NOT NULL,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    UNIQUE(org_id, name)
+);
+
+-- Step 2: Copy data with Crede org_id
+INSERT INTO sections_new (id, org_id, name, abbreviation, parent_section_id, display_order, is_active)
+SELECT id, 'org_crede_001', name, abbreviation, parent_section_id, display_order, is_active FROM sections;
+
+-- Step 3: Drop old table
+DROP TABLE sections;
+
+-- Step 4: Rename new table
+ALTER TABLE sections_new RENAME TO sections;
+
+-- Step 5: Recreate indexes
+CREATE INDEX IF NOT EXISTS idx_sections_org ON sections(org_id);
+CREATE INDEX IF NOT EXISTS idx_sections_display_order ON sections(display_order);

--- a/apps/vault/src/lib/server/constants.ts
+++ b/apps/vault/src/lib/server/constants.ts
@@ -1,0 +1,10 @@
+// Server-side constants for the vault application
+// These provide defaults during the Schema V2 migration period
+
+/**
+ * Default organization ID for legacy single-org vault deployments.
+ * Used as fallback when org context is not yet available.
+ * 
+ * TODO: Remove after #165 (subdomain routing) is implemented.
+ */
+export const DEFAULT_ORG_ID = 'org_crede_001';

--- a/apps/vault/src/lib/server/db/queries/members.ts
+++ b/apps/vault/src/lib/server/db/queries/members.ts
@@ -9,6 +9,7 @@ import type { Section, Voice } from '$lib/types';
  */
 interface SectionRow {
 	id: string;
+	org_id: string;
 	name: string;
 	abbreviation: string;
 	parent_section_id: string | null;
@@ -42,7 +43,7 @@ export async function queryMemberSections(
 ): Promise<Section[]> {
 	const { results } = await db
 		.prepare(
-			`SELECT s.id, s.name, s.abbreviation, s.parent_section_id, s.display_order, s.is_active, ms.is_primary
+			`SELECT s.id, s.org_id, s.name, s.abbreviation, s.parent_section_id, s.display_order, s.is_active, ms.is_primary
 			 FROM sections s
 			 JOIN member_sections ms ON s.id = ms.section_id
 			 WHERE ms.member_id = ?
@@ -53,6 +54,7 @@ export async function queryMemberSections(
 
 	return results.map((row) => ({
 		id: row.id,
+		orgId: row.org_id,
 		name: row.name,
 		abbreviation: row.abbreviation,
 		parentSectionId: row.parent_section_id,
@@ -95,7 +97,7 @@ export async function queryMemberVoices(db: D1Database, memberId: string): Promi
 export async function queryInviteSections(db: D1Database, inviteId: string): Promise<Section[]> {
 	const { results } = await db
 		.prepare(
-			`SELECT s.id, s.name, s.abbreviation, s.parent_section_id, s.display_order, s.is_active, isc.is_primary
+			`SELECT s.id, s.org_id, s.name, s.abbreviation, s.parent_section_id, s.display_order, s.is_active, isc.is_primary
 			 FROM sections s
 			 JOIN invite_sections isc ON s.id = isc.section_id
 			 WHERE isc.invite_id = ?
@@ -106,6 +108,7 @@ export async function queryInviteSections(db: D1Database, inviteId: string): Pro
 
 	return results.map((row) => ({
 		id: row.id,
+		orgId: row.org_id,
 		name: row.name,
 		abbreviation: row.abbreviation,
 		parentSectionId: row.parent_section_id,

--- a/apps/vault/src/lib/server/db/roster.ts
+++ b/apps/vault/src/lib/server/db/roster.ts
@@ -45,6 +45,7 @@ function buildEventsQuery(filters?: RosterViewFilters): { sql: string; params: s
 function buildMembersQuery(filters?: RosterViewFilters): { sql: string; params: string[] } {
 	let sql = `SELECT DISTINCT m.*, 
 	       ms.section_id as primary_section, 
+	       s.org_id as section_org_id,
 	       s.name as section_name, 
 	       s.abbreviation as section_abbr,
 	       s.is_active as section_is_active,
@@ -182,6 +183,7 @@ export async function getRosterView(
 			name: string;
 			nickname: string | null;
 			primary_section: string | null;
+			section_org_id: string | null;
 			section_name: string | null;
 			section_abbr: string | null;
 			section_is_active: number | null;
@@ -246,9 +248,10 @@ export async function getRosterView(
 			
 			// Use primary section from the query result (preserves sort order)
 			// The query already joined with primary section and ordered by display_order
-			const primarySection = member.primary_section && member.section_name
+			const primarySection = member.primary_section && member.section_name && member.section_org_id
 				? {
 					id: member.primary_section,
+					orgId: member.section_org_id,
 					name: member.section_name,
 					abbreviation: member.section_abbr ?? '',
 					parentSectionId: null,

--- a/apps/vault/src/lib/types.ts
+++ b/apps/vault/src/lib/types.ts
@@ -93,9 +93,11 @@ export interface Voice {
 /**
  * Section: Performance assignment (where you DO sing)
  * Example: Thomas performs in Tenor 2
+ * Sections are per-organization (Schema V2)
  */
 export interface Section {
 	id: string;
+	orgId: string; // Schema V2: sections are per-organization
 	name: string;
 	abbreviation: string;
 	parentSectionId: string | null;
@@ -161,6 +163,7 @@ export interface CreateVoiceInput {
  * Input for creating a new section
  */
 export interface CreateSectionInput {
+	orgId: string; // Schema V2: required
 	name: string;
 	abbreviation: string;
 	parentSectionId?: string;

--- a/apps/vault/src/routes/api/sections/+server.ts
+++ b/apps/vault/src/routes/api/sections/+server.ts
@@ -19,6 +19,10 @@ export async function POST({ request, platform, cookies }: RequestEvent) {
 	const body = (await request.json()) as Partial<CreateSectionInput>;
 
 	// Validate required fields
+	if (!body.orgId || typeof body.orgId !== 'string' || body.orgId.trim().length === 0) {
+		return json({ error: 'Organization ID is required' }, { status: 400 });
+	}
+
 	if (!body.name || typeof body.name !== 'string' || body.name.trim().length === 0) {
 		return json({ error: 'Name is required' }, { status: 400 });
 	}
@@ -29,6 +33,7 @@ export async function POST({ request, platform, cookies }: RequestEvent) {
 
 	// Build input with defaults
 	const input: CreateSectionInput = {
+		orgId: body.orgId.trim(),
 		name: body.name.trim(),
 		abbreviation: body.abbreviation.trim(),
 		parentSectionId: body.parentSectionId ?? undefined,

--- a/apps/vault/src/routes/editions/+page.server.ts
+++ b/apps/vault/src/routes/editions/+page.server.ts
@@ -3,6 +3,7 @@ import { getMemberById } from '$lib/server/db/members';
 import { getAllEditions, type EditionWithWork } from '$lib/server/db/editions';
 import { canUploadScores } from '$lib/server/auth/permissions';
 import { getAllSections } from '$lib/server/db/sections';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 import type { Section } from '$lib/types';
 
 export const load: PageServerLoad = async ({ platform, cookies }) => {
@@ -11,9 +12,12 @@ export const load: PageServerLoad = async ({ platform, cookies }) => {
 		return { editions: [], sections: [], canManage: false };
 	}
 
+	// TODO: Get orgId from subdomain routing (#165)
+	const orgId = DEFAULT_ORG_ID;
+
 	const [editions, sections] = await Promise.all([
 		getAllEditions(db),
-		getAllSections(db)
+		getAllSections(db, orgId)
 	]);
 
 	// Get current user's permissions (librarian can manage editions)

--- a/apps/vault/src/routes/editions/[id]/+page.server.ts
+++ b/apps/vault/src/routes/editions/[id]/+page.server.ts
@@ -7,6 +7,7 @@ import { getAllSections } from '$lib/server/db/sections';
 import { canUploadScores } from '$lib/server/auth/permissions';
 import { getPhysicalCopiesByEdition } from '$lib/server/db/physical-copies';
 import { getActiveAssignments, getEditionAssignmentHistory, getCurrentHolders, type AssignmentHistoryEntry, type CurrentHolder } from '$lib/server/db/copy-assignments';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 
 interface CopyWithAssignment {
 	id: string;
@@ -106,8 +107,11 @@ export const load: PageServerLoad = async ({ params, platform, cookies }) => {
 
 	const canManage = await checkCanManage(db, cookies.get('member_id'));
 
+	// TODO: Get orgId from subdomain routing (#165)
+	const orgId = DEFAULT_ORG_ID;
+
 	const [sections, librarianData] = await Promise.all([
-		getAllSections(db),
+		getAllSections(db, orgId),
 		loadLibrarianData(db, params.id, canManage)
 	]);
 

--- a/apps/vault/src/routes/events/roster/+page.server.ts
+++ b/apps/vault/src/routes/events/roster/+page.server.ts
@@ -7,6 +7,7 @@ import type { Section } from '$lib/types';
 
 interface SectionRow {
 	id: string;
+	org_id: string;
 	name: string;
 	abbreviation: string;
 	parent_section_id: string | null;
@@ -26,7 +27,7 @@ interface RosterFilters {
 async function getActiveSections(db: D1Database): Promise<Section[]> {
 	const { results } = await db
 		.prepare(
-			`SELECT DISTINCT s.id, s.name, s.abbreviation, s.parent_section_id, s.display_order, s.is_active
+			`SELECT DISTINCT s.id, s.org_id, s.name, s.abbreviation, s.parent_section_id, s.display_order, s.is_active
 			 FROM sections s
 			 JOIN member_sections ms ON s.id = ms.section_id
 			 WHERE ms.is_primary = 1 AND s.is_active = 1
@@ -36,6 +37,7 @@ async function getActiveSections(db: D1Database): Promise<Section[]> {
 
 	return results.map((row) => ({
 		id: row.id,
+		orgId: row.org_id,
 		name: row.name,
 		abbreviation: row.abbreviation,
 		parentSectionId: row.parent_section_id,

--- a/apps/vault/src/routes/invite/+page.server.ts
+++ b/apps/vault/src/routes/invite/+page.server.ts
@@ -5,6 +5,7 @@ import { getAuthenticatedMember, assertAdmin, isOwner } from '$lib/server/auth/m
 import { getActiveVoices } from '$lib/server/db/voices';
 import { getActiveSections } from '$lib/server/db/sections';
 import { getMemberById } from '$lib/server/db/members';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 
 export const load: PageServerLoad = async ({ platform, cookies, url }) => {
 	const db = platform?.env?.DB;
@@ -16,10 +17,13 @@ export const load: PageServerLoad = async ({ platform, cookies, url }) => {
 	const member = await getAuthenticatedMember(db, cookies);
 	assertAdmin(member);
 
+	// TODO: Get orgId from subdomain routing (#165)
+	const orgId = DEFAULT_ORG_ID;
+
 	// Load active voices and sections for the form
 	const [voices, sections] = await Promise.all([
 		getActiveVoices(db),
-		getActiveSections(db)
+		getActiveSections(db, orgId)
 	]);
 
 	// Check for roster member ID (new flow - inviting existing roster member)

--- a/apps/vault/src/routes/members/+page.server.ts
+++ b/apps/vault/src/routes/members/+page.server.ts
@@ -6,6 +6,7 @@ import { getPendingInvites } from '$lib/server/db/invites';
 import { getAllMembers } from '$lib/server/db/members';
 import { getActiveVoices } from '$lib/server/db/voices';
 import { getActiveSections } from '$lib/server/db/sections';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 
 export const load: PageServerLoad = async ({ platform, cookies, url }) => {
 	const db = platform?.env?.DB;
@@ -70,8 +71,10 @@ export const load: PageServerLoad = async ({ platform, cookies, url }) => {
 
 	// Get available voices and sections for adding
 	console.log('[members] Loading available voices and sections...');
+	// TODO: Get orgId from subdomain routing (#165)
+	const orgId = DEFAULT_ORG_ID;
 	const availableVoices = await getActiveVoices(db);
-	const availableSections = await getActiveSections(db);
+	const availableSections = await getActiveSections(db, orgId);
 	console.log('[members] Loaded:', { voices: availableVoices.length, sections: availableSections.length });
 
 	console.log('[members] Page load complete for user:', currentUser.id);

--- a/apps/vault/src/routes/members/[id]/+page.server.ts
+++ b/apps/vault/src/routes/members/[id]/+page.server.ts
@@ -6,6 +6,7 @@ import { getAuthenticatedMember } from '$lib/server/auth/middleware';
 import { getActiveVoices } from '$lib/server/db/voices';
 import { getActiveSections } from '$lib/server/db/sections';
 import { getMemberAssignedCopies, type AssignedCopyWithDetails } from '$lib/server/db/copy-assignments';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 
 interface AuthContext {
 	currentUser: Member | null;
@@ -33,9 +34,11 @@ async function loadAuthContext(db: D1Database, cookies: unknown): Promise<AuthCo
 
 async function loadAdminData(db: D1Database, isAdmin: boolean) {
 	if (!isAdmin) return { availableVoices: [], availableSections: [] };
+	// TODO: Get orgId from subdomain routing (#165)
+	const orgId = DEFAULT_ORG_ID;
 	const [availableVoices, availableSections] = await Promise.all([
 		getActiveVoices(db),
-		getActiveSections(db)
+		getActiveSections(db, orgId)
 	]);
 	return { availableVoices, availableSections };
 }

--- a/apps/vault/src/routes/members/add-roster/+page.server.ts
+++ b/apps/vault/src/routes/members/add-roster/+page.server.ts
@@ -4,6 +4,7 @@ import type { PageServerLoad } from './$types';
 import { getAuthenticatedMember, assertAdmin } from '$lib/server/auth/middleware';
 import { getActiveVoices } from '$lib/server/db/voices';
 import { getActiveSections } from '$lib/server/db/sections';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 
 export const load: PageServerLoad = async ({ platform, cookies }) => {
 	const db = platform?.env?.DB;
@@ -15,9 +16,12 @@ export const load: PageServerLoad = async ({ platform, cookies }) => {
 	const currentUser = await getAuthenticatedMember(db, cookies);
 	assertAdmin(currentUser);
 
+	// TODO: Get orgId from subdomain routing (#165)
+	const orgId = DEFAULT_ORG_ID;
+
 	// Load available voices and sections for multi-select
 	const availableVoices = await getActiveVoices(db);
-	const availableSections = await getActiveSections(db);
+	const availableSections = await getActiveSections(db, orgId);
 
 	return {
 		availableVoices,

--- a/apps/vault/src/routes/settings/+page.server.ts
+++ b/apps/vault/src/routes/settings/+page.server.ts
@@ -3,6 +3,7 @@ import { getAuthenticatedMember, assertAdmin } from '$lib/server/auth/middleware
 import { getAllSettings } from '$lib/server/db/settings';
 import { getAllVoicesWithCounts } from '$lib/server/db/voices';
 import { getAllSectionsWithCounts } from '$lib/server/db/sections';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ platform, cookies }) => {
@@ -13,11 +14,14 @@ export const load: PageServerLoad = async ({ platform, cookies }) => {
 	const member = await getAuthenticatedMember(db, cookies);
 	assertAdmin(member);
 
+	// TODO: Get orgId from subdomain routing (#165)
+	const orgId = DEFAULT_ORG_ID;
+
 	// Load settings, voices (with counts), and sections (with counts)
 	const [settings, voices, sections] = await Promise.all([
 		getAllSettings(db),
 		getAllVoicesWithCounts(db),
-		getAllSectionsWithCounts(db)
+		getAllSectionsWithCounts(db, orgId)
 	]);
 
 	return {

--- a/apps/vault/src/routes/works/[id]/+page.server.ts
+++ b/apps/vault/src/routes/works/[id]/+page.server.ts
@@ -5,6 +5,7 @@ import { canUploadScores } from '$lib/server/auth/permissions';
 import { getWorkById } from '$lib/server/db/works';
 import { getEditionsByWorkId } from '$lib/server/db/editions';
 import { getAllSections } from '$lib/server/db/sections';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 
 async function checkCanManage(db: D1Database, memberId: string | undefined): Promise<boolean> {
 	if (!memberId) return false;
@@ -22,9 +23,12 @@ export const load: PageServerLoad = async ({ params, platform, cookies }) => {
 	const work = await getWorkById(db, workId);
 	if (!work) throw error(404, 'Work not found');
 
+	// TODO: Get orgId from subdomain routing (#165)
+	const orgId = DEFAULT_ORG_ID;
+
 	const [editions, sections, canManage] = await Promise.all([
 		getEditionsByWorkId(db, workId),
-		getAllSections(db),
+		getAllSections(db, orgId),
 		checkCanManage(db, cookies.get('member_id'))
 	]);
 

--- a/apps/vault/src/tests/routes/api/members/roster.spec.ts
+++ b/apps/vault/src/tests/routes/api/members/roster.spec.ts
@@ -137,7 +137,7 @@ describe('POST /api/members/roster', () => {
 			email_contact: 'jane@example.com',
 			roles: [],
 			voices: [{ id: 'voice1', name: 'Soprano', abbreviation: 'S', category: 'vocal' as const, rangeGroup: 'upper', displayOrder: 1, isActive: true }],
-			sections: [{ id: 'sec1', name: 'Soprano 1', abbreviation: 'S1', parentSectionId: null, displayOrder: 1, isActive: true }],
+			sections: [{ id: 'sec1', orgId: 'org_crede_001', name: 'Soprano 1', abbreviation: 'S1', parentSectionId: null, displayOrder: 1, isActive: true }],
 			invited_by: 'admin-id',
 			joined_at: '2024-01-15T00:00:00Z'
 		};

--- a/apps/vault/src/tests/routes/api/profile.spec.ts
+++ b/apps/vault/src/tests/routes/api/profile.spec.ts
@@ -197,7 +197,7 @@ describe('PATCH /api/profile', () => {
 				{ id: 'v1', name: 'Tenor', abbreviation: 'T', category: 'vocal' as const, rangeGroup: 'medium', displayOrder: 1, isActive: true }
 			],
 			sections: [
-				{ id: 's1', name: 'Tenor 1', abbreviation: 'T1', parentSectionId: null, displayOrder: 1, isActive: true }
+				{ id: 's1', orgId: 'org_crede_001', name: 'Tenor 1', abbreviation: 'T1', parentSectionId: null, displayOrder: 1, isActive: true }
 			]
 		};
 		vi.mocked(updateMemberName).mockResolvedValue(updatedMember);

--- a/apps/vault/src/tests/routes/api/sections.spec.ts
+++ b/apps/vault/src/tests/routes/api/sections.spec.ts
@@ -51,6 +51,7 @@ const mockAdmin: Member = {
 // Sample section data
 const mockSection: Section & { assignmentCount?: number } = {
 	id: 'section-1',
+	orgId: 'org_crede_001',
 	name: 'Soprano 1',
 	abbreviation: 'S1',
 	parentSectionId: null,
@@ -108,6 +109,7 @@ describe('POST /api/sections', () => {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
+					orgId: 'org_crede_001',
 					name: 'Tenor 1',
 					abbreviation: 'T1'
 				})
@@ -118,6 +120,7 @@ describe('POST /api/sections', () => {
 
 		expect(response.status).toBe(201);
 		expect(createSection).toHaveBeenCalledWith({}, {
+			orgId: 'org_crede_001',
 			name: 'Tenor 1',
 			abbreviation: 'T1',
 			parentSectionId: undefined,
@@ -132,6 +135,7 @@ describe('POST /api/sections', () => {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
+					orgId: 'org_crede_001',
 					name: 'Tenor 1',
 					abbreviation: 'T1',
 					parentSectionId: 'parent-section',
@@ -145,6 +149,7 @@ describe('POST /api/sections', () => {
 
 		expect(response.status).toBe(201);
 		expect(createSection).toHaveBeenCalledWith({}, {
+			orgId: 'org_crede_001',
 			name: 'Tenor 1',
 			abbreviation: 'T1',
 			parentSectionId: 'parent-section',
@@ -162,11 +167,27 @@ describe('POST /api/sections', () => {
 			request: new Request('http://localhost/api/sections', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ name: 'Test', abbreviation: 'T' })
+				body: JSON.stringify({ orgId: 'org_crede_001', name: 'Test', abbreviation: 'T' })
 			})
 		});
 
 		await expect(POST(event)).rejects.toMatchObject({ status: 403 });
+	});
+
+	it('returns 400 if orgId is missing', async () => {
+		const event = createMockEvent({
+			request: new Request('http://localhost/api/sections', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: 'Tenor 1', abbreviation: 'T1' })
+			})
+		});
+
+		const response = await POST(event);
+
+		expect(response.status).toBe(400);
+		const data = await response.json() as { error: string };
+		expect(data.error).toContain('Organization ID');
 	});
 
 	it('returns 400 if name is missing', async () => {
@@ -174,7 +195,7 @@ describe('POST /api/sections', () => {
 			request: new Request('http://localhost/api/sections', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ abbreviation: 'T1' })
+				body: JSON.stringify({ orgId: 'org_crede_001', abbreviation: 'T1' })
 			})
 		});
 
@@ -190,7 +211,7 @@ describe('POST /api/sections', () => {
 			request: new Request('http://localhost/api/sections', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ name: 'Tenor 1' })
+				body: JSON.stringify({ orgId: 'org_crede_001', name: 'Tenor 1' })
 			})
 		});
 
@@ -208,7 +229,7 @@ describe('POST /api/sections', () => {
 			request: new Request('http://localhost/api/sections', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ name: 'Soprano 1', abbreviation: 'S1' })
+				body: JSON.stringify({ orgId: 'org_crede_001', name: 'Soprano 1', abbreviation: 'S1' })
 			})
 		});
 
@@ -373,7 +394,7 @@ describe('POST /api/sections/reorder', () => {
 			request: new Request('http://localhost/api/sections/reorder', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ sectionIds: ['section-2', 'section-1', 'section-3'] })
+				body: JSON.stringify({ orgId: 'org_crede_001', sectionIds: ['section-2', 'section-1', 'section-3'] })
 			})
 		});
 
@@ -381,7 +402,23 @@ describe('POST /api/sections/reorder', () => {
 
 		expect(response.status).toBe(200);
 		expect(reorderSections).toHaveBeenCalledWith({}, ['section-2', 'section-1', 'section-3']);
-		expect(getAllSectionsWithCounts).toHaveBeenCalled();
+		expect(getAllSectionsWithCounts).toHaveBeenCalledWith({}, 'org_crede_001');
+	});
+
+	it('returns 400 if orgId is missing', async () => {
+		const event = createMockEvent({
+			request: new Request('http://localhost/api/sections/reorder', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ sectionIds: ['section-1'] })
+			})
+		});
+
+		const response = await REORDER(event);
+
+		expect(response.status).toBe(400);
+		const data = await response.json() as { error: string };
+		expect(data.error).toContain('orgId');
 	});
 
 	it('returns 400 if sectionIds is missing', async () => {
@@ -389,7 +426,7 @@ describe('POST /api/sections/reorder', () => {
 			request: new Request('http://localhost/api/sections/reorder', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({})
+				body: JSON.stringify({ orgId: 'org_crede_001' })
 			})
 		});
 
@@ -403,7 +440,7 @@ describe('POST /api/sections/reorder', () => {
 			request: new Request('http://localhost/api/sections/reorder', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ sectionIds: 'section-1' })
+				body: JSON.stringify({ orgId: 'org_crede_001', sectionIds: 'section-1' })
 			})
 		});
 
@@ -417,7 +454,7 @@ describe('POST /api/sections/reorder', () => {
 			request: new Request('http://localhost/api/sections/reorder', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ sectionIds: [] })
+				body: JSON.stringify({ orgId: 'org_crede_001', sectionIds: [] })
 			})
 		});
 
@@ -431,7 +468,7 @@ describe('POST /api/sections/reorder', () => {
 			request: new Request('http://localhost/api/sections/reorder', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ sectionIds: ['section-1', 123, 'section-2'] })
+				body: JSON.stringify({ orgId: 'org_crede_001', sectionIds: ['section-1', 123, 'section-2'] })
 			})
 		});
 
@@ -449,7 +486,7 @@ describe('POST /api/sections/reorder', () => {
 			request: new Request('http://localhost/api/sections/reorder', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ sectionIds: ['section-1'] })
+				body: JSON.stringify({ orgId: 'org_crede_001', sectionIds: ['section-1'] })
 			})
 		});
 


### PR DESCRIPTION
## Summary
Adds `org_id` column to the `sections` table as part of Epic #158 Schema V2 Multi-Organization Implementation.

## Changes
- **Migration 0028**: Rebuild sections table with `org_id` column using SQLite table rebuild pattern
  - Add `UNIQUE(org_id, name)` constraint (same section name allowed in different orgs)
  - Migrate existing sections to Crede org (`org_crede_001`)
- **Section interface**: Add required `orgId: string` field
- **CreateSectionInput**: Add required `orgId: string` field
- **Section queries**: All functions now filter by `org_id`
  - `getActiveSections(db, orgId)`
  - `getAllSections(db, orgId)`
  - `getAllSectionsWithCounts(db, orgId)`
- **Section ID generation**: `${orgId}-${name.toLowerCase()}`
- **DEFAULT_ORG_ID constant**: Fallback for routes until subdomain routing (#165)
- **API endpoints**: Now require `orgId` in request body
- **Query updates**: Add `org_id` to section results in `queries/members.ts` and `roster.ts`

## Testing
- 19 section-specific tests with org scoping
- 850 vault tests passing
- 960 total tests across all packages

## Backward Compatibility
- Existing sections migrated to `org_crede_001` (Crede org)
- `DEFAULT_ORG_ID` constant provides fallback until #165 (subdomain routing)

## Related Issues
- Implements #162
- Part of Epic #158 (Schema V2 Multi-Organization)
- Blocked by: #161 ✅ (member_roles with org_id)
- Blocks: #165 (subdomain routing)