### PR TITLE
feat(vault): add org_id to content tables (#163)

### DIFF
--- a/apps/vault/migrations/0029_content_org_id.sql
+++ b/apps/vault/migrations/0029_content_org_id.sql
@@ -1,0 +1,54 @@
+-- Migration 0029: Add org_id to content tables (Schema V2)
+-- Part of Epic #158: Multi-Organization Implementation
+-- Issue #163: Add org_id to content tables
+
+-- Note: SQLite allows ALTER TABLE ADD COLUMN without NOT NULL constraint
+-- Using nullable org_id for now; can add NOT NULL via table rebuild if needed
+
+-- ============================================================================
+-- EVENTS
+-- ============================================================================
+ALTER TABLE events ADD COLUMN org_id TEXT REFERENCES organizations(id) ON DELETE CASCADE;
+UPDATE events SET org_id = 'org_crede_001';
+CREATE INDEX IF NOT EXISTS idx_events_org ON events(org_id);
+
+-- ============================================================================
+-- WORKS
+-- ============================================================================
+ALTER TABLE works ADD COLUMN org_id TEXT REFERENCES organizations(id) ON DELETE CASCADE;
+UPDATE works SET org_id = 'org_crede_001';
+CREATE INDEX IF NOT EXISTS idx_works_org ON works(org_id);
+
+-- ============================================================================
+-- SEASONS
+-- Seasons now scoped per-org: same start_date allowed in different orgs
+-- ============================================================================
+-- SQLite: Table rebuild needed to change UNIQUE constraint from (start_date) to (org_id, start_date)
+CREATE TABLE seasons_new (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    start_date TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(org_id, start_date)
+);
+
+-- Migrate existing seasons to Crede org
+INSERT INTO seasons_new (id, org_id, name, start_date, created_at, updated_at)
+SELECT id, 'org_crede_001', name, start_date, created_at, updated_at
+FROM seasons;
+
+DROP TABLE seasons;
+ALTER TABLE seasons_new RENAME TO seasons;
+
+-- Recreate indexes
+CREATE INDEX IF NOT EXISTS idx_seasons_start_date ON seasons(start_date);
+CREATE INDEX IF NOT EXISTS idx_seasons_org ON seasons(org_id);
+
+-- ============================================================================
+-- INVITES
+-- ============================================================================
+ALTER TABLE invites ADD COLUMN org_id TEXT REFERENCES organizations(id) ON DELETE CASCADE;
+UPDATE invites SET org_id = 'org_crede_001';
+CREATE INDEX IF NOT EXISTS idx_invites_org ON invites(org_id);

--- a/apps/vault/src/lib/server/db/event-repertoire.ts
+++ b/apps/vault/src/lib/server/db/event-repertoire.ts
@@ -247,6 +247,7 @@ interface EventWorkRow {
 	added_at: string;
 	added_by: string | null;
 	w_id: string;
+	w_org_id: string;
 	w_title: string;
 	w_composer: string | null;
 	w_lyricist: string | null;
@@ -313,7 +314,7 @@ function groupEditionsByEventWork(editions: EditionRow[]): Map<string, EventRepe
 function mapEventWorkRow(ew: EventWorkRow, editionsMap: Map<string, EventRepertoireEdition[]>): EventRepertoireWork {
 	return {
 		eventWorkId: ew.id,
-		work: { id: ew.w_id, title: ew.w_title, composer: ew.w_composer, lyricist: ew.w_lyricist, createdAt: ew.w_created_at },
+		work: { id: ew.w_id, orgId: ew.w_org_id, title: ew.w_title, composer: ew.w_composer, lyricist: ew.w_lyricist, createdAt: ew.w_created_at },
 		displayOrder: ew.display_order,
 		notes: ew.notes,
 		editions: editionsMap.get(ew.id) ?? []
@@ -327,7 +328,7 @@ export async function getEventRepertoire(db: D1Database, eventId: string): Promi
 	const eventWorks = await db
 		.prepare(
 			`SELECT ew.id, ew.event_id, ew.work_id, ew.display_order, ew.notes, ew.added_at, ew.added_by,
-				w.id as w_id, w.title as w_title, w.composer as w_composer, w.lyricist as w_lyricist, w.created_at as w_created_at
+				w.id as w_id, w.org_id as w_org_id, w.title as w_title, w.composer as w_composer, w.lyricist as w_lyricist, w.created_at as w_created_at
 			FROM event_works ew JOIN works w ON ew.work_id = w.id WHERE ew.event_id = ? ORDER BY ew.display_order ASC`
 		)
 		.bind(eventId)

--- a/apps/vault/src/lib/server/db/season-repertoire.ts
+++ b/apps/vault/src/lib/server/db/season-repertoire.ts
@@ -229,6 +229,7 @@ interface SeasonWorkRow {
 	added_at: string;
 	added_by: string | null;
 	w_id: string;
+	w_org_id: string;
 	w_title: string;
 	w_composer: string | null;
 	w_lyricist: string | null;
@@ -295,7 +296,7 @@ function groupEditionsBySeasonWork(editions: EditionRow[]): Map<string, SeasonRe
 function mapSeasonWorkRow(sw: SeasonWorkRow, editionsMap: Map<string, SeasonRepertoireEdition[]>): SeasonRepertoireWork {
 	return {
 		seasonWorkId: sw.id,
-		work: { id: sw.w_id, title: sw.w_title, composer: sw.w_composer, lyricist: sw.w_lyricist, createdAt: sw.w_created_at },
+		work: { id: sw.w_id, orgId: sw.w_org_id, title: sw.w_title, composer: sw.w_composer, lyricist: sw.w_lyricist, createdAt: sw.w_created_at },
 		displayOrder: sw.display_order,
 		notes: sw.notes,
 		editions: editionsMap.get(sw.id) ?? []
@@ -309,7 +310,7 @@ export async function getSeasonRepertoire(db: D1Database, seasonId: string): Pro
 	const seasonWorks = await db
 		.prepare(
 			`SELECT sw.id, sw.season_id, sw.work_id, sw.display_order, sw.notes, sw.added_at, sw.added_by,
-				w.id as w_id, w.title as w_title, w.composer as w_composer, w.lyricist as w_lyricist, w.created_at as w_created_at
+				w.id as w_id, w.org_id as w_org_id, w.title as w_title, w.composer as w_composer, w.lyricist as w_lyricist, w.created_at as w_created_at
 			FROM season_works sw JOIN works w ON sw.work_id = w.id WHERE sw.season_id = ? ORDER BY sw.display_order ASC`
 		)
 		.bind(seasonId)

--- a/apps/vault/src/lib/types.ts
+++ b/apps/vault/src/lib/types.ts
@@ -328,9 +328,11 @@ export interface RosterViewFilters {
 /**
  * Work: Abstract composition (independent of specific publications)
  * Example: "Messiah" by Handel (may have many Editions)
+ * Scoped per-organization (Schema V2)
  */
 export interface Work {
 	id: string;
+	orgId: string;
 	title: string;
 	composer: string | null;
 	lyricist: string | null;
@@ -341,6 +343,7 @@ export interface Work {
  * Input for creating a new work
  */
 export interface CreateWorkInput {
+	orgId: string;
 	title: string;
 	composer?: string;
 	lyricist?: string;

--- a/apps/vault/src/routes/api/events/+server.ts
+++ b/apps/vault/src/routes/api/events/+server.ts
@@ -6,6 +6,7 @@ import { createEvents, getUpcomingEvents } from '$lib/server/db/events';
 import { parseBody, createEventsSchema } from '$lib/server/validation/schemas';
 import { canCreateEvents } from '$lib/server/auth/permissions';
 import { getAuthenticatedMember } from '$lib/server/auth/middleware';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 
 /**
  * GET /api/events
@@ -20,7 +21,10 @@ export async function GET(event: RequestEvent) {
 	// Require authentication
 	const member = await getAuthenticatedMember(db, cookies);
 
-	const events = await getUpcomingEvents(db);
+	// TODO: #165 - Get orgId from subdomain routing
+	const orgId = DEFAULT_ORG_ID;
+
+	const events = await getUpcomingEvents(db, orgId);
 	return json(events);
 }
 
@@ -41,8 +45,11 @@ export async function POST(event: RequestEvent) {
 		throw error(403, 'Only conductors and admins can create events');
 	}
 
+	// TODO: #165 - Get orgId from subdomain routing
+	const orgId = DEFAULT_ORG_ID;
+
 	const body = await parseBody(request, createEventsSchema);
-	const createdEvents = await createEvents(db, body.events, member.id);
+	const createdEvents = await createEvents(db, orgId, body.events, member.id);
 
 	return json({ events: createdEvents });
 }

--- a/apps/vault/src/routes/api/members/invite/+server.ts
+++ b/apps/vault/src/routes/api/members/invite/+server.ts
@@ -3,6 +3,7 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getAuthenticatedMember, assertAdmin, isOwner } from '$lib/server/auth/middleware';
 import { parseBody, createInviteSchema } from '$lib/server/validation/schemas';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 
 export const POST: RequestHandler = async ({ request, platform, cookies }) => {
 	const db = platform?.env?.DB;
@@ -13,6 +14,9 @@ export const POST: RequestHandler = async ({ request, platform, cookies }) => {
 	// Auth: get member and check admin role
 	const member = await getAuthenticatedMember(db, cookies);
 	assertAdmin(member);
+
+	// TODO: #165 - Get orgId from subdomain routing
+	const orgId = DEFAULT_ORG_ID;
 
 	// Validate request body with Zod
 	const body = await parseBody(request, createInviteSchema);
@@ -28,6 +32,7 @@ export const POST: RequestHandler = async ({ request, platform, cookies }) => {
 
 		// Create invite linked to roster member
 		const invite = await createInvite(db, {
+			orgId,
 			rosterMemberId: body.rosterMemberId,
 			roles: body.roles,
 			emailHint: body.emailHint,

--- a/apps/vault/src/routes/events/[id]/+page.server.ts
+++ b/apps/vault/src/routes/events/[id]/+page.server.ts
@@ -9,6 +9,7 @@ import { getParticipation } from '$lib/server/db/participation';
 import { getEventRepertoire } from '$lib/server/db/event-repertoire';
 import { getEventMaterialsForMember } from '$lib/server/db/event-materials';
 import { getAllWorks } from '$lib/server/db/works';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 import type { Edition } from '$lib/types';
 
 export const load: PageServerLoad = async ({ platform, cookies, params }) => {
@@ -17,6 +18,9 @@ export const load: PageServerLoad = async ({ platform, cookies, params }) => {
 
 	// Require authentication
 	const member = await getAuthenticatedMember(db, cookies);
+
+	// TODO: #165 - Get orgId from subdomain routing
+	const orgId = DEFAULT_ORG_ID;
 
 	const eventId = params.id;
 	if (!eventId) {
@@ -51,8 +55,8 @@ export const load: PageServerLoad = async ({ platform, cookies, params }) => {
 	// Load event repertoire (works + editions)
 	const repertoire = await getEventRepertoire(db, eventId);
 	
-	// Load all works for adding to repertoire
-	const allWorks = await getAllWorks(db);
+	// Load all works for this organization for adding to repertoire
+	const allWorks = await getAllWorks(db, orgId);
 	
 	// Works already in event repertoire
 	const eventWorkIds = new Set(repertoire.works.map(w => w.work.id));

--- a/apps/vault/src/routes/library/reports/collection/+page.server.ts
+++ b/apps/vault/src/routes/library/reports/collection/+page.server.ts
@@ -6,6 +6,7 @@ import { getMemberById } from '$lib/server/db/members';
 import { canUploadScores } from '$lib/server/auth/permissions';
 import { getOutstandingCopiesForSeason } from '$lib/server/db/inventory-reports';
 import { getAllSeasons } from '$lib/server/db/seasons';
+import { DEFAULT_ORG_ID } from '$lib/server/constants';
 
 export const load: PageServerLoad = async ({ platform, cookies, url }) => {
 	const db = platform?.env?.DB;
@@ -19,8 +20,11 @@ export const load: PageServerLoad = async ({ platform, cookies, url }) => {
 	const member = await getMemberById(db, memberId);
 	if (!canUploadScores(member)) throw redirect(302, '/');
 
-	// Get all seasons
-	const seasons = await getAllSeasons(db);
+	// TODO: #165 - Get orgId from subdomain routing
+	const orgId = DEFAULT_ORG_ID;
+
+	// Get all seasons for this organization
+	const seasons = await getAllSeasons(db, orgId);
 
 	// Get selected season from query param, or default to most recent season
 	const seasonId = url.searchParams.get('season');

--- a/apps/vault/src/routes/members/+page.server.ts
+++ b/apps/vault/src/routes/members/+page.server.ts
@@ -51,9 +51,12 @@ export const load: PageServerLoad = async ({ platform, cookies, url }) => {
 		roles: m.roles
 	}));
 
-	// Get pending invites
+	// TODO: #165 - Get orgId from subdomain routing
+	const orgId = DEFAULT_ORG_ID;
+
+	// Get pending invites for this organization
 	console.log('[members] Loading pending invites...');
-	const pendingInvites = await getPendingInvites(db);
+	const pendingInvites = await getPendingInvites(db, orgId);
 	console.log('[members] Loaded invites:', { count: pendingInvites.length });
 	const baseUrl = `${url.origin}/invite/accept`;
 	const invites = pendingInvites.map((inv) => ({
@@ -71,8 +74,6 @@ export const load: PageServerLoad = async ({ platform, cookies, url }) => {
 
 	// Get available voices and sections for adding
 	console.log('[members] Loading available voices and sections...');
-	// TODO: Get orgId from subdomain routing (#165)
-	const orgId = DEFAULT_ORG_ID;
 	const availableVoices = await getActiveVoices(db);
 	const availableSections = await getActiveSections(db, orgId);
 	console.log('[members] Loaded:', { voices: availableVoices.length, sections: availableSections.length });

--- a/apps/vault/src/routes/works/+page.server.ts
+++ b/apps/vault/src/routes/works/+page.server.ts
@@ -4,6 +4,7 @@ import { canUploadScores } from '$lib/server/auth/permissions';
 
 interface WorksResponse {
 	id: string;
+	orgId: string;
 	title: string;
 	composer: string | null;
 	lyricist: string | null;

--- a/apps/vault/src/tests/routes/api/works.spec.ts
+++ b/apps/vault/src/tests/routes/api/works.spec.ts
@@ -43,8 +43,12 @@ const mockMember = {
 	sections: []
 };
 
+// Test org ID (matches DEFAULT_ORG_ID used in routes)
+const TEST_ORG_ID = 'org_crede_001';
+
 const mockWork: Work = {
 	id: 'work-1',
+	orgId: TEST_ORG_ID,
 	title: 'Test Work',
 	composer: 'Test Composer',
 	lyricist: null,
@@ -99,7 +103,8 @@ describe('Works API Routes', () => {
 			});
 			const response = await GET(event);
 
-			expect(mockSearchWorks).toHaveBeenCalledWith(expect.anything(), 'Test');
+			// searchWorks now takes (db, orgId, query)
+			expect(mockSearchWorks).toHaveBeenCalledWith(expect.anything(), TEST_ORG_ID, 'Test');
 			expect(mockGetAllWorks).not.toHaveBeenCalled();
 			
 			const data = await response.json();


### PR DESCRIPTION
## Summary
Schema V2 Phase 4: Add organization scoping to content tables (events, works, seasons, invites).

## Changes
- **Migration 0029**: Add org_id column to events, works, seasons, and invites tables
- **TypeScript interfaces**: Add orgId property to Event, Work, Season, and Invite types
- **Database functions**: All CRUD operations now accept/return orgId
- **API routes**: Updated to use DEFAULT_ORG_ID (placeholder for #165 subdomain routing)
- **Page routes**: All pages pass orgId to database functions
- **Tests**: All 850 tests updated and passing

## Pattern Established
- Interface: `orgId: string`
- Row: `org_id: string`
- Mapping: `org_id` → `orgId`
- Queries filter by org_id
- Routes use DEFAULT_ORG_ID constant

## Files Changed (23 files)
- Migration: `0029_content_org_id.sql`
- DB layer: events.ts, works.ts, seasons.ts, invites.ts, event-repertoire.ts, season-repertoire.ts
- Types: types.ts
- API routes: /api/events, /api/works, /api/seasons, /api/members/invite
- Page routes: events, works, members, library reports
- Tests: events.spec.ts, works.spec.ts, seasons.spec.ts, invites-roster.spec.ts, api/works.spec.ts

Closes #163
Part of Epic #158