### PR TITLE
feat(vault): add affiliations table with history tracking

### DIFF
--- a/apps/vault/migrations/0030_affiliations.sql
+++ b/apps/vault/migrations/0030_affiliations.sql
@@ -1,0 +1,23 @@
+-- Migration 0030: Add affiliations table (Schema V2)
+-- Part of Epic #158: Multi-Organization Implementation
+-- Issue #164: Add affiliations table with history tracking
+
+-- Tracks collective ↔ umbrella relationships with history
+CREATE TABLE affiliations (
+    id TEXT PRIMARY KEY,
+    collective_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    umbrella_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+    left_at TEXT,  -- NULL = active, set = ended
+    UNIQUE(collective_id, umbrella_id, joined_at)  -- history uniqueness
+);
+
+-- Partial unique index: only one ACTIVE affiliation per collective-umbrella pair
+-- SQLite supports partial indexes with WHERE clause
+CREATE UNIQUE INDEX idx_affiliations_active
+ON affiliations(collective_id, umbrella_id)
+WHERE left_at IS NULL;
+
+-- Lookup indexes
+CREATE INDEX idx_affiliations_collective ON affiliations(collective_id);
+CREATE INDEX idx_affiliations_umbrella ON affiliations(umbrella_id);

--- a/apps/vault/src/lib/server/db/affiliations.spec.ts
+++ b/apps/vault/src/lib/server/db/affiliations.spec.ts
@@ -1,0 +1,398 @@
+// Affiliations database layer tests
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	createAffiliation,
+	endAffiliation,
+	getAffiliationById,
+	getActiveAffiliations,
+	getAffiliationHistory,
+	getUmbrellaMembers,
+	getCollectiveUmbrellas
+} from './affiliations';
+import type { Affiliation } from '$lib/types';
+
+// Test IDs
+const COLLECTIVE_ID = 'org_crede_001';
+const UMBRELLA_ID = 'org_umbrella_001';
+const OTHER_COLLECTIVE_ID = 'org_other_002';
+
+// Mock D1Database
+function createMockDb() {
+	const affiliations: Map<string, Record<string, unknown>> = new Map();
+	const affiliationsByToken: Map<string, string> = new Map();
+
+	return {
+		prepare: (sql: string) => ({
+			bind: (...params: unknown[]) => ({
+				run: async () => {
+					const lowerSql = sql.toLowerCase();
+
+					// Handle INSERT INTO affiliations
+					if (lowerSql.includes('insert into affiliations')) {
+						const [id, collective_id, umbrella_id, joined_at] = params as string[];
+
+						// Check for active affiliation (simulate partial unique index)
+						for (const aff of affiliations.values()) {
+							if (
+								aff.collective_id === collective_id &&
+								aff.umbrella_id === umbrella_id &&
+								aff.left_at === null
+							) {
+								throw new Error('UNIQUE constraint failed');
+							}
+						}
+
+						affiliations.set(id, {
+							id,
+							collective_id,
+							umbrella_id,
+							joined_at,
+							left_at: null
+						});
+						return { meta: { changes: 1 } };
+					}
+
+					// Handle UPDATE affiliations (end affiliation)
+					if (lowerSql.includes('update affiliations') && lowerSql.includes('left_at')) {
+						const [left_at, collective_id, umbrella_id] = params as string[];
+						let changes = 0;
+
+						for (const [id, aff] of affiliations.entries()) {
+							if (
+								aff.collective_id === collective_id &&
+								aff.umbrella_id === umbrella_id &&
+								aff.left_at === null
+							) {
+								aff.left_at = left_at;
+								affiliations.set(id, aff);
+								changes++;
+							}
+						}
+
+						return { meta: { changes } };
+					}
+
+					return { meta: { changes: 0 } };
+				},
+				first: async () => {
+					const lowerSql = sql.toLowerCase();
+
+					// Handle SELECT by id
+					if (lowerSql.includes('where id = ?')) {
+						const [id] = params as string[];
+						return affiliations.get(id) ?? null;
+					}
+
+					return null;
+				},
+				all: async () => {
+					const lowerSql = sql.toLowerCase();
+
+					// Handle SELECT umbrella members - must check BEFORE active affiliations
+					// SQL: WHERE umbrella_id = ? AND left_at IS NULL (no collective_id in WHERE)
+					if (
+						lowerSql.includes('where umbrella_id = ?') &&
+						lowerSql.includes('left_at is null') &&
+						!lowerSql.includes('collective_id =')
+					) {
+						const [umbrellaId] = params as string[];
+						const results = Array.from(affiliations.values()).filter(
+							(a) => a.umbrella_id === umbrellaId && a.left_at === null
+						);
+						return { results };
+					}
+
+					// Handle SELECT collective umbrellas
+					// SQL: WHERE collective_id = ? AND left_at IS NULL (no umbrella_id in WHERE condition)
+					if (
+						lowerSql.includes('where collective_id = ?') &&
+						lowerSql.includes('left_at is null') &&
+						!lowerSql.includes('umbrella_id =')
+					) {
+						const [collectiveId] = params as string[];
+						const results = Array.from(affiliations.values()).filter(
+							(a) => a.collective_id === collectiveId && a.left_at === null
+						);
+						return { results };
+					}
+
+					// Handle SELECT active affiliations for org
+					// SQL: WHERE (collective_id = ? OR umbrella_id = ?) AND left_at IS NULL
+					if (
+						lowerSql.includes('collective_id = ? or umbrella_id = ?') &&
+						lowerSql.includes('left_at is null')
+					) {
+						const [orgId] = params as string[];
+						const results = Array.from(affiliations.values()).filter(
+							(a) =>
+								(a.collective_id === orgId || a.umbrella_id === orgId) && a.left_at === null
+						);
+						return { results };
+					}
+
+					// Handle SELECT history for collective-umbrella pair
+					// SQL: WHERE collective_id = ? AND umbrella_id = ? (no left_at IS NULL filter)
+					if (
+						lowerSql.includes('collective_id = ? and umbrella_id = ?') &&
+						!lowerSql.includes('left_at is null')
+					) {
+						const [collectiveId, umbrellaId] = params as string[];
+						const results = Array.from(affiliations.values())
+							.filter((a) => a.collective_id === collectiveId && a.umbrella_id === umbrellaId)
+							.sort((a, b) => (b.joined_at as string).localeCompare(a.joined_at as string));
+						return { results };
+					}
+
+					return { results: [] };
+				}
+			})
+		})
+	} as unknown as D1Database;
+}
+
+describe('Affiliations database layer', () => {
+	let db: D1Database;
+
+	beforeEach(() => {
+		db = createMockDb();
+	});
+
+	describe('createAffiliation', () => {
+		it('creates affiliation between collective and umbrella', async () => {
+			const affiliation = await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+
+			expect(affiliation.collectiveId).toBe(COLLECTIVE_ID);
+			expect(affiliation.umbrellaId).toBe(UMBRELLA_ID);
+			expect(affiliation.leftAt).toBeNull();
+			expect(affiliation.id).toBeDefined();
+			expect(affiliation.joinedAt).toBeDefined();
+		});
+
+		it('rejects duplicate active affiliation', async () => {
+			// Create first affiliation
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+
+			// Try to create duplicate
+			await expect(
+				createAffiliation(db, {
+					collectiveId: COLLECTIVE_ID,
+					umbrellaId: UMBRELLA_ID
+				})
+			).rejects.toThrow('UNIQUE constraint');
+		});
+
+		it('allows affiliation after previous one ended', async () => {
+			// Create and end first affiliation
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+			await endAffiliation(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			// Create new affiliation (should succeed)
+			const affiliation = await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+
+			expect(affiliation.collectiveId).toBe(COLLECTIVE_ID);
+			expect(affiliation.leftAt).toBeNull();
+		});
+	});
+
+	describe('endAffiliation', () => {
+		it('ends active affiliation', async () => {
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+
+			const ended = await endAffiliation(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			expect(ended).toBe(true);
+		});
+
+		it('returns false when no active affiliation exists', async () => {
+			const ended = await endAffiliation(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			expect(ended).toBe(false);
+		});
+
+		it('returns false when affiliation already ended', async () => {
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+			await endAffiliation(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			// Try to end again
+			const ended = await endAffiliation(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			expect(ended).toBe(false);
+		});
+	});
+
+	describe('getAffiliationById', () => {
+		it('returns affiliation by ID', async () => {
+			const created = await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+
+			const affiliation = await getAffiliationById(db, created.id);
+
+			expect(affiliation).not.toBeNull();
+			expect(affiliation?.id).toBe(created.id);
+			expect(affiliation?.collectiveId).toBe(COLLECTIVE_ID);
+		});
+
+		it('returns null for non-existent ID', async () => {
+			const affiliation = await getAffiliationById(db, 'non-existent');
+
+			expect(affiliation).toBeNull();
+		});
+	});
+
+	describe('getActiveAffiliations', () => {
+		it('returns empty array when no affiliations', async () => {
+			const affiliations = await getActiveAffiliations(db, COLLECTIVE_ID);
+
+			expect(affiliations).toEqual([]);
+		});
+
+		it('returns active affiliations for collective', async () => {
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+
+			const affiliations = await getActiveAffiliations(db, COLLECTIVE_ID);
+
+			expect(affiliations).toHaveLength(1);
+			expect(affiliations[0].collectiveId).toBe(COLLECTIVE_ID);
+		});
+
+		it('returns active affiliations for umbrella', async () => {
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+
+			const affiliations = await getActiveAffiliations(db, UMBRELLA_ID);
+
+			expect(affiliations).toHaveLength(1);
+			expect(affiliations[0].umbrellaId).toBe(UMBRELLA_ID);
+		});
+
+		it('excludes ended affiliations', async () => {
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+			await endAffiliation(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			const affiliations = await getActiveAffiliations(db, COLLECTIVE_ID);
+
+			expect(affiliations).toHaveLength(0);
+		});
+	});
+
+	describe('getAffiliationHistory', () => {
+		it('returns empty array when no history', async () => {
+			const history = await getAffiliationHistory(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			expect(history).toEqual([]);
+		});
+
+		it('returns full history including ended affiliations', async () => {
+			// Create first affiliation
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+			await endAffiliation(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			// Create second affiliation
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+
+			const history = await getAffiliationHistory(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			expect(history).toHaveLength(2);
+			// Most recent first (by joined_at DESC)
+			// Should have one active and one ended
+			const activeCount = history.filter(a => a.leftAt === null).length;
+			const endedCount = history.filter(a => a.leftAt !== null).length;
+			expect(activeCount).toBe(1);
+			expect(endedCount).toBe(1);
+		});
+	});
+
+	describe('getUmbrellaMembers', () => {
+		it('returns all active collectives under umbrella', async () => {
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+			await createAffiliation(db, {
+				collectiveId: OTHER_COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+
+			const members = await getUmbrellaMembers(db, UMBRELLA_ID);
+
+			expect(members).toHaveLength(2);
+		});
+
+		it('excludes ended affiliations', async () => {
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+			await endAffiliation(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			const members = await getUmbrellaMembers(db, UMBRELLA_ID);
+
+			expect(members).toHaveLength(0);
+		});
+	});
+
+	describe('getCollectiveUmbrellas', () => {
+		it('returns all active umbrellas for collective', async () => {
+			const UMBRELLA_2_ID = 'org_umbrella_002';
+
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_2_ID
+			});
+
+			const umbrellas = await getCollectiveUmbrellas(db, COLLECTIVE_ID);
+
+			expect(umbrellas).toHaveLength(2);
+		});
+
+		it('excludes ended affiliations', async () => {
+			await createAffiliation(db, {
+				collectiveId: COLLECTIVE_ID,
+				umbrellaId: UMBRELLA_ID
+			});
+			await endAffiliation(db, COLLECTIVE_ID, UMBRELLA_ID);
+
+			const umbrellas = await getCollectiveUmbrellas(db, COLLECTIVE_ID);
+
+			expect(umbrellas).toHaveLength(0);
+		});
+	});
+});

--- a/apps/vault/src/lib/server/db/affiliations.ts
+++ b/apps/vault/src/lib/server/db/affiliations.ts
@@ -1,0 +1,185 @@
+// Affiliations database layer
+// Tracks collective ↔ umbrella relationships with history
+
+import type { Affiliation, CreateAffiliationInput } from '$lib/types';
+
+// Database row interface (snake_case)
+interface AffiliationRow {
+	id: string;
+	collective_id: string;
+	umbrella_id: string;
+	joined_at: string;
+	left_at: string | null;
+}
+
+// Simple ID generator
+function generateId(): string {
+	return crypto.randomUUID().replace(/-/g, '').slice(0, 21);
+}
+
+/**
+ * Map database row (snake_case) to TypeScript type (camelCase)
+ */
+function rowToAffiliation(row: AffiliationRow): Affiliation {
+	return {
+		id: row.id,
+		collectiveId: row.collective_id,
+		umbrellaId: row.umbrella_id,
+		joinedAt: row.joined_at,
+		leftAt: row.left_at
+	};
+}
+
+/**
+ * Create a new affiliation between a collective and an umbrella
+ * @throws Error if active affiliation already exists
+ */
+export async function createAffiliation(
+	db: D1Database,
+	input: CreateAffiliationInput
+): Promise<Affiliation> {
+	const id = generateId();
+	const joinedAt = new Date().toISOString();
+
+	// The partial unique index will reject if an active affiliation already exists
+	// This will throw a UNIQUE constraint error
+	await db
+		.prepare(
+			`INSERT INTO affiliations (id, collective_id, umbrella_id, joined_at)
+			 VALUES (?, ?, ?, ?)`
+		)
+		.bind(id, input.collectiveId, input.umbrellaId, joinedAt)
+		.run();
+
+	return {
+		id,
+		collectiveId: input.collectiveId,
+		umbrellaId: input.umbrellaId,
+		joinedAt,
+		leftAt: null
+	};
+}
+
+/**
+ * End an active affiliation (sets left_at)
+ * @returns true if affiliation was ended, false if not found or already ended
+ */
+export async function endAffiliation(
+	db: D1Database,
+	collectiveId: string,
+	umbrellaId: string
+): Promise<boolean> {
+	const leftAt = new Date().toISOString();
+
+	const result = await db
+		.prepare(
+			`UPDATE affiliations
+			 SET left_at = ?
+			 WHERE collective_id = ? AND umbrella_id = ? AND left_at IS NULL`
+		)
+		.bind(leftAt, collectiveId, umbrellaId)
+		.run();
+
+	return (result.meta.changes ?? 0) > 0;
+}
+
+/**
+ * Get an affiliation by ID
+ */
+export async function getAffiliationById(
+	db: D1Database,
+	id: string
+): Promise<Affiliation | null> {
+	const row = await db
+		.prepare(
+			`SELECT id, collective_id, umbrella_id, joined_at, left_at
+			 FROM affiliations WHERE id = ?`
+		)
+		.bind(id)
+		.first<AffiliationRow>();
+
+	return row ? rowToAffiliation(row) : null;
+}
+
+/**
+ * Get all active affiliations for an organization (as collective or umbrella)
+ */
+export async function getActiveAffiliations(
+	db: D1Database,
+	orgId: string
+): Promise<Affiliation[]> {
+	const { results } = await db
+		.prepare(
+			`SELECT id, collective_id, umbrella_id, joined_at, left_at
+			 FROM affiliations
+			 WHERE (collective_id = ? OR umbrella_id = ?) AND left_at IS NULL
+			 ORDER BY joined_at ASC`
+		)
+		.bind(orgId, orgId)
+		.all<AffiliationRow>();
+
+	return results.map(rowToAffiliation);
+}
+
+/**
+ * Get full affiliation history for a collective-umbrella pair
+ * Ordered by joined_at descending (most recent first)
+ */
+export async function getAffiliationHistory(
+	db: D1Database,
+	collectiveId: string,
+	umbrellaId: string
+): Promise<Affiliation[]> {
+	const { results } = await db
+		.prepare(
+			`SELECT id, collective_id, umbrella_id, joined_at, left_at
+			 FROM affiliations
+			 WHERE collective_id = ? AND umbrella_id = ?
+			 ORDER BY joined_at DESC`
+		)
+		.bind(collectiveId, umbrellaId)
+		.all<AffiliationRow>();
+
+	return results.map(rowToAffiliation);
+}
+
+/**
+ * Get all active collectives under an umbrella
+ */
+export async function getUmbrellaMembers(
+	db: D1Database,
+	umbrellaId: string
+): Promise<Affiliation[]> {
+	const { results } = await db
+		.prepare(
+			`SELECT id, collective_id, umbrella_id, joined_at, left_at
+			 FROM affiliations
+			 WHERE umbrella_id = ? AND left_at IS NULL
+			 ORDER BY joined_at ASC`
+		)
+		.bind(umbrellaId)
+		.all<AffiliationRow>();
+
+	return results.map(rowToAffiliation);
+}
+
+/**
+ * Get all active umbrellas for a collective
+ * (A collective can belong to multiple umbrellas)
+ */
+export async function getCollectiveUmbrellas(
+	db: D1Database,
+	collectiveId: string
+): Promise<Affiliation[]> {
+	const { results } = await db
+		.prepare(
+			`SELECT id, collective_id, umbrella_id, joined_at, left_at
+			 FROM affiliations
+			 WHERE collective_id = ? AND left_at IS NULL
+			 ORDER BY joined_at ASC`
+		)
+		.bind(collectiveId)
+		.all<AffiliationRow>();
+
+	return results.map(rowToAffiliation);
+}

--- a/apps/vault/src/lib/types.ts
+++ b/apps/vault/src/lib/types.ts
@@ -73,6 +73,30 @@ export interface AddMemberToOrgInput {
 }
 
 // ============================================================================
+// AFFILIATIONS SYSTEM (Schema V2 - Issue #164)
+// ============================================================================
+
+/**
+ * Affiliation: Relationship between collective and umbrella organizations
+ * Tracks history (leftAt = null means active)
+ */
+export interface Affiliation {
+	id: string;
+	collectiveId: string;
+	umbrellaId: string;
+	joinedAt: string;
+	leftAt: string | null; // null = active
+}
+
+/**
+ * Input for creating a new affiliation
+ */
+export interface CreateAffiliationInput {
+	collectiveId: string;
+	umbrellaId: string;
+}
+
+// ============================================================================
 // VOICES & SECTIONS SYSTEM
 // ============================================================================
 


### PR DESCRIPTION
## Summary
Implements #164 - Add affiliations table with history tracking

## Changes
- **Migration 0030**: Creates  table with:
  - `collective_id` and `umbrella_id` references to organizations
  - `joined_at` and `left_at` timestamps for history tracking
  - Partial unique index to enforce one active affiliation per pair
  - Lookup indexes for efficient queries

- **Type definitions**: Added `Affiliation` and `CreateAffiliationInput` interfaces

- **CRUD operations** (`affiliations.ts`):
  - `createAffiliation()` - Create new affiliation (constraint prevents duplicates)
  - `endAffiliation()` - Set `left_at` to end affiliation
  - `getAffiliationById()` - Lookup by ID
  - `getActiveAffiliations()` - All active for an org (as collective or umbrella)
  - `getAffiliationHistory()` - Full history for a collective-umbrella pair
  - `getUmbrellaMembers()` - Active collectives under an umbrella
  - `getCollectiveUmbrellas()` - Active umbrellas for a collective

- **18 unit tests** covering all operations and edge cases

## Testing
```bash
pnpm test -- --run src/lib/server/db/affiliations.spec.ts
# 18 passed
```

## Part of
Epic #158: Schema V2 Multi-Organization Implementation

Closes #164