### PR TITLE
refactor(vault): consolidate Member interface definitions

### DIFF
--- a/apps/vault/src/lib/server/auth/permissions.ts
+++ b/apps/vault/src/lib/server/auth/permissions.ts
@@ -1,6 +1,13 @@
 // Permission system for role-based access control
 
-export type Role = 'owner' | 'admin' | 'librarian' | 'conductor' | 'section_leader';
+import type { Role, MemberAuthContext } from '$lib/types';
+
+// Re-export for consumers that import from here
+export type { Role, MemberAuthContext };
+
+// Deprecated: Use MemberAuthContext from types.ts
+// Keeping alias for backward compatibility
+export type Member = MemberAuthContext;
 
 export type Permission =
 	| 'scores:view'
@@ -15,13 +22,6 @@ export type Permission =
 	| 'events:manage'
 	| 'events:delete'
 	| 'attendance:record';
-
-export interface Member {
-	id: string;
-	roles: Role[]; // Aggregate roles (for backward compat)
-	email_id: string | null; // OAuth identity
-	orgRoles?: Record<string, Role[]>; // Org-specific roles (Schema V2)
-}
 
 export interface RequireRoleResult {
 	success: boolean;
@@ -46,7 +46,7 @@ const PERMISSIONS: Record<Role, Permission[]> = {
  * @param orgId Optional org ID to get org-specific roles
  * @returns Array of roles (from orgRoles if orgId provided and available, else from roles)
  */
-function getMemberRoles(member: Member, orgId?: string): Role[] {
+function getMemberRoles(member: MemberAuthContext, orgId?: string): Role[] {
 	if (orgId && member.orgRoles) {
 		return member.orgRoles[orgId] ?? [];
 	}

--- a/apps/vault/src/lib/server/db/members.ts
+++ b/apps/vault/src/lib/server/db/members.ts
@@ -1,19 +1,9 @@
 // Member database operations
-import type { Role, Voice, Section } from '$lib/types';
+import type { Role, Voice, Section, Member } from '$lib/types';
 import { queryMemberSections, queryMemberVoices } from './queries/members';
 
-export interface Member {
-	id: string;
-	name: string; // Now required (NOT NULL)
-	nickname: string | null; // Optional compact display name
-	email_id: string | null; // OAuth identity (was: email)
-	email_contact: string | null; // Contact preference (NEW)
-	roles: Role[]; // Multiple roles via junction table
-	voices: Voice[]; // Member's vocal capabilities (what they CAN sing)
-	sections: Section[]; // Member's current assignments (where they DO sing)
-	invited_by: string | null;
-	joined_at: string;
-}
+// Re-export Member from canonical types
+export type { Member };
 
 export interface CreateMemberInput {
 	email: string; // For OAuth registration (becomes email_id)

--- a/apps/vault/src/lib/types.ts
+++ b/apps/vault/src/lib/types.ts
@@ -97,6 +97,34 @@ export interface CreateAffiliationInput {
 }
 
 // ============================================================================
+// MEMBER SYSTEM
+// ============================================================================
+
+/**
+ * Full member record from database
+ * Canonical definition - used throughout the vault application
+ */
+export interface Member {
+	id: string;
+	name: string;
+	nickname: string | null;
+	email_id: string | null; // OAuth identity
+	email_contact: string | null; // Contact preference
+	roles: Role[]; // Aggregate roles (multi-role system)
+	voices: Voice[];
+	sections: Section[];
+	invited_by: string | null;
+	joined_at: string;
+	orgRoles?: Record<string, Role[]>; // Org-specific roles (Schema V2)
+}
+
+/**
+ * Minimal member context for permission checks
+ * Used by hasPermission(), hasRole(), requireRole()
+ */
+export type MemberAuthContext = Pick<Member, 'id' | 'roles' | 'email_id' | 'orgRoles'>;
+
+// ============================================================================
 // VOICES & SECTIONS SYSTEM
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Consolidates the duplicate `Member` interface definitions into a single source of truth.

Closes #170

## Changes

### types.ts
- Added canonical `Member` interface (full DB record with all fields)
- Added `MemberAuthContext` type (`Pick<Member, 'id' | 'roles' | 'email_id' | 'orgRoles'>`) for permission checks

### permissions.ts
- Now imports `Role` and `MemberAuthContext` from types.ts
- Re-exports both for backward compatibility
- Keeps `Member` as type alias: `export type Member = MemberAuthContext`

### members.ts
- Now imports `Member` from types.ts instead of defining locally
- Re-exports for consumers

## Before

```
permissions.ts: Member = { id, roles, email_id, orgRoles }
members.ts:     Member = { id, name, nickname, email_id, ... }  
```

## After

```
types.ts:       Member = { ... all fields ... }
                MemberAuthContext = Pick<Member, minimal auth fields>
permissions.ts: imports MemberAuthContext (alias as Member for compat)
members.ts:     imports Member
```

## Testing

- ✅ 877 vault tests pass
- ✅ 90 registry tests pass
- ✅ 20 shared tests pass
- ✅ Type check clean

## Notes

Discovered legacy `src/lib/server/db/permissions.ts` with outdated Role type (`admin | librarian | singer`) and broken query (`SELECT role FROM members`). Out of scope for this issue - recommend separate cleanup.