### PR TITLE
feat(i18n): Add cascading preference resolution service

### DIFF
--- a/apps/vault/src/lib/server/i18n/preferences.spec.ts
+++ b/apps/vault/src/lib/server/i18n/preferences.spec.ts
@@ -1,0 +1,184 @@
+// Tests for i18n preference resolution service (Epic #183, Issue #187)
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { D1Database } from '@cloudflare/workers-types';
+import { resolvePreferences, SYSTEM_DEFAULTS } from './preferences';
+
+// Mock D1Database for testing
+function createMockDB(config: {
+	memberPrefs?: { language?: string | null; locale?: string | null; timezone?: string | null } | null;
+	orgSettings?: { language?: string | null; locale?: string | null; timezone?: string | null } | null;
+}): D1Database {
+	return {
+		prepare: (sql: string) => {
+			return {
+				bind: (..._params: any[]) => ({
+					first: async () => {
+						if (sql.includes('FROM member_preferences')) {
+							if (!config.memberPrefs) return null;
+							return {
+								member_id: 'test-member',
+								language: config.memberPrefs.language ?? null,
+								locale: config.memberPrefs.locale ?? null,
+								timezone: config.memberPrefs.timezone ?? null,
+								updated_at: new Date().toISOString()
+							};
+						}
+						if (sql.includes('FROM organizations')) {
+							if (!config.orgSettings) return null;
+							return {
+								id: 'test-org',
+								name: 'Test Org',
+								language: config.orgSettings.language ?? null,
+								locale: config.orgSettings.locale ?? null,
+								timezone: config.orgSettings.timezone ?? null
+							};
+						}
+						return null;
+					}
+				})
+			};
+		}
+	} as unknown as D1Database;
+}
+
+describe('I18n Preference Resolution', () => {
+	describe('resolvePreferences', () => {
+		describe('full cascade: member → org → system', () => {
+			it('uses member preferences when all are set', async () => {
+				const db = createMockDB({
+					memberPrefs: { language: 'et', locale: 'et-EE', timezone: 'Europe/Tallinn' },
+					orgSettings: { language: 'en', locale: 'en-US', timezone: 'America/New_York' }
+				});
+
+				const result = await resolvePreferences(db, 'test-member', 'test-org');
+
+				expect(result.language).toBe('et');
+				expect(result.locale).toBe('et-EE');
+				expect(result.timezone).toBe('Europe/Tallinn');
+				expect(result.source.language).toBe('member');
+				expect(result.source.locale).toBe('member');
+				expect(result.source.timezone).toBe('member');
+			});
+
+			it('falls back to org when member has no preferences', async () => {
+				const db = createMockDB({
+					memberPrefs: null,
+					orgSettings: { language: 'de', locale: 'de-DE', timezone: 'Europe/Berlin' }
+				});
+
+				const result = await resolvePreferences(db, 'test-member', 'test-org');
+
+				expect(result.language).toBe('de');
+				expect(result.locale).toBe('de-DE');
+				expect(result.timezone).toBe('Europe/Berlin');
+				expect(result.source.language).toBe('organization');
+				expect(result.source.locale).toBe('organization');
+				expect(result.source.timezone).toBe('organization');
+			});
+
+			it('falls back to system when both member and org are null', async () => {
+				const db = createMockDB({
+					memberPrefs: null,
+					orgSettings: { language: null, locale: null, timezone: null }
+				});
+
+				const result = await resolvePreferences(db, 'test-member', 'test-org');
+
+				expect(result.language).toBe(SYSTEM_DEFAULTS.language);
+				expect(result.locale).toBe(SYSTEM_DEFAULTS.locale);
+				expect(result.timezone).toBe(SYSTEM_DEFAULTS.timezone);
+				expect(result.source.language).toBe('system');
+				expect(result.source.locale).toBe('system');
+				expect(result.source.timezone).toBe('system');
+			});
+
+			it('mixes sources when partially set', async () => {
+				const db = createMockDB({
+					memberPrefs: { language: 'et', locale: null, timezone: null },
+					orgSettings: { language: 'en', locale: 'en-GB', timezone: null }
+				});
+
+				const result = await resolvePreferences(db, 'test-member', 'test-org');
+
+				expect(result.language).toBe('et');
+				expect(result.source.language).toBe('member');
+
+				expect(result.locale).toBe('en-GB');
+				expect(result.source.locale).toBe('organization');
+
+				expect(result.timezone).toBe(SYSTEM_DEFAULTS.timezone);
+				expect(result.source.timezone).toBe('system');
+			});
+		});
+
+		describe('anonymous users (no member)', () => {
+			it('uses org settings when memberId is null', async () => {
+				const db = createMockDB({
+					memberPrefs: null,
+					orgSettings: { language: 'et', locale: 'et-EE', timezone: 'Europe/Tallinn' }
+				});
+
+				const result = await resolvePreferences(db, null, 'test-org');
+
+				expect(result.language).toBe('et');
+				expect(result.locale).toBe('et-EE');
+				expect(result.timezone).toBe('Europe/Tallinn');
+				expect(result.source.language).toBe('organization');
+				expect(result.source.locale).toBe('organization');
+				expect(result.source.timezone).toBe('organization');
+			});
+
+			it('falls back to system defaults for anonymous with no org settings', async () => {
+				const db = createMockDB({
+					memberPrefs: null,
+					orgSettings: { language: null, locale: null, timezone: null }
+				});
+
+				const result = await resolvePreferences(db, null, 'test-org');
+
+				expect(result.language).toBe(SYSTEM_DEFAULTS.language);
+				expect(result.locale).toBe(SYSTEM_DEFAULTS.locale);
+				expect(result.timezone).toBe(SYSTEM_DEFAULTS.timezone);
+			});
+		});
+
+		describe('edge cases', () => {
+			it('handles org not found gracefully', async () => {
+				const db = createMockDB({
+					memberPrefs: null,
+					orgSettings: null
+				});
+
+				const result = await resolvePreferences(db, 'test-member', 'non-existent');
+
+				// Should fall back to system defaults
+				expect(result.language).toBe(SYSTEM_DEFAULTS.language);
+				expect(result.locale).toBe(SYSTEM_DEFAULTS.locale);
+				expect(result.timezone).toBe(SYSTEM_DEFAULTS.timezone);
+			});
+
+			it('member preferences override org even when member prefs are empty strings', async () => {
+				// Empty string is different from null - it means "explicitly set to nothing"
+				// But in our case, we treat empty strings as null (unset)
+				const db = createMockDB({
+					memberPrefs: { language: '', locale: '', timezone: '' },
+					orgSettings: { language: 'en', locale: 'en-US', timezone: 'America/New_York' }
+				});
+
+				const result = await resolvePreferences(db, 'test-member', 'test-org');
+
+				// Empty strings should be treated as null, so fall back to org
+				expect(result.language).toBe('en');
+				expect(result.source.language).toBe('organization');
+			});
+		});
+	});
+
+	describe('SYSTEM_DEFAULTS', () => {
+		it('has sensible defaults', () => {
+			expect(SYSTEM_DEFAULTS.language).toBe('en');
+			expect(SYSTEM_DEFAULTS.locale).toBe('en-US');
+			expect(SYSTEM_DEFAULTS.timezone).toBe('UTC');
+		});
+	});
+});

--- a/apps/vault/src/lib/server/i18n/preferences.ts
+++ b/apps/vault/src/lib/server/i18n/preferences.ts
@@ -1,0 +1,133 @@
+// i18n preference resolution service (Epic #183, Issue #187)
+// Resolves effective preferences using cascade: Member → Organization → System
+
+/**
+ * System-level defaults when no preferences are set
+ */
+export const SYSTEM_DEFAULTS = {
+	language: 'en',
+	locale: 'en-US',
+	timezone: 'UTC'
+} as const;
+
+/**
+ * Source of each resolved preference
+ */
+export type PreferenceSource = 'member' | 'organization' | 'system';
+
+/**
+ * Resolved i18n preferences with source tracking
+ */
+export interface ResolvedI18nPreferences {
+	/** Resolved language code (ISO 639-1) */
+	language: string;
+	/** Resolved locale code (BCP 47) */
+	locale: string;
+	/** Resolved timezone (IANA) */
+	timezone: string;
+	/** Where each preference was resolved from */
+	source: {
+		language: PreferenceSource;
+		locale: PreferenceSource;
+		timezone: PreferenceSource;
+	};
+}
+
+interface MemberPreferencesRow {
+	member_id: string;
+	language: string | null;
+	locale: string | null;
+	timezone: string | null;
+	updated_at: string;
+}
+
+interface OrganizationRow {
+	id: string;
+	name: string;
+	language: string | null;
+	locale: string | null;
+	timezone: string | null;
+}
+
+/**
+ * Resolve effective i18n preferences for a member in an organization
+ * 
+ * Resolution cascade:
+ * 1. Member preferences (if set and not empty)
+ * 2. Organization settings (if set and not empty)
+ * 3. System defaults
+ * 
+ * @param db - D1 database connection
+ * @param memberId - Member ID (null for anonymous/unauthenticated)
+ * @param orgId - Organization ID
+ * @returns Resolved preferences with source tracking
+ */
+export async function resolvePreferences(
+	db: D1Database,
+	memberId: string | null,
+	orgId: string
+): Promise<ResolvedI18nPreferences> {
+	// Fetch member preferences (if authenticated)
+	let memberPrefs: MemberPreferencesRow | null = null;
+	if (memberId) {
+		memberPrefs = await db
+			.prepare('SELECT * FROM member_preferences WHERE member_id = ?')
+			.bind(memberId)
+			.first<MemberPreferencesRow>();
+	}
+
+	// Fetch organization settings
+	const orgSettings = await db
+		.prepare('SELECT id, name, language, locale, timezone FROM organizations WHERE id = ?')
+		.bind(orgId)
+		.first<OrganizationRow>();
+
+	// Resolve each preference with source tracking
+	const resolveValue = (
+		memberValue: string | null | undefined,
+		orgValue: string | null | undefined,
+		systemDefault: string
+	): { value: string; source: PreferenceSource } => {
+		// Check member preference (non-null, non-empty)
+		if (memberValue && memberValue.trim() !== '') {
+			return { value: memberValue, source: 'member' };
+		}
+
+		// Check organization setting (non-null, non-empty)
+		if (orgValue && orgValue.trim() !== '') {
+			return { value: orgValue, source: 'organization' };
+		}
+
+		// Fall back to system default
+		return { value: systemDefault, source: 'system' };
+	};
+
+	const language = resolveValue(
+		memberPrefs?.language,
+		orgSettings?.language,
+		SYSTEM_DEFAULTS.language
+	);
+
+	const locale = resolveValue(
+		memberPrefs?.locale,
+		orgSettings?.locale,
+		SYSTEM_DEFAULTS.locale
+	);
+
+	const timezone = resolveValue(
+		memberPrefs?.timezone,
+		orgSettings?.timezone,
+		SYSTEM_DEFAULTS.timezone
+	);
+
+	return {
+		language: language.value,
+		locale: locale.value,
+		timezone: timezone.value,
+		source: {
+			language: language.source,
+			locale: locale.source,
+			timezone: timezone.source
+		}
+	};
+}


### PR DESCRIPTION
## Summary
Implements #187 - Cascading i18n preference resolution service (Epic #183).

## Changes

### New Service
`apps/vault/src/lib/server/i18n/preferences.ts`

### Interface
```typescript
export interface ResolvedI18nPreferences {
  language: string;   // Always resolved
  locale: string;     // Always resolved  
  timezone: string;   // Always resolved
  source: {
    language: 'member' | 'organization' | 'system';
    locale: 'member' | 'organization' | 'system';
    timezone: 'member' | 'organization' | 'system';
  };
}

export async function resolvePreferences(
  db: D1Database,
  memberId: string | null,
  orgId: string
): Promise<ResolvedI18nPreferences>;
```

### Resolution Cascade
1. **Member preferences** (if set and non-empty)
2. **Organization settings** (if set and non-empty)
3. **System defaults** (en, en-US, UTC)

### Features
- Source tracking for UI display ("inherited from organization")
- Handles anonymous users (org defaults only)
- Treats empty strings as unset (falls through)

## Testing
- 9 new tests covering full cascade, anonymous users, edge cases
- All 910 vault tests passing

## Next Steps
This service will be integrated into:
- Layout server load function (#185, #186)
- Date/time formatters
- Translation framework (#188)

Closes #187