### PR TITLE
feat(vault): Organization settings UI for i18n (#185)

### DIFF
--- a/apps/vault/src/routes/api/organizations/[id]/+server.ts
+++ b/apps/vault/src/routes/api/organizations/[id]/+server.ts
@@ -1,0 +1,69 @@
+// API endpoint for organization i18n settings (Issue #185)
+// GET /api/organizations/[id] - Get organization details
+// PATCH /api/organizations/[id] - Update organization i18n settings
+
+import { json, error } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getAuthenticatedMember, assertAdmin } from '$lib/server/auth/middleware';
+import { updateOrganization, getOrganizationById } from '$lib/server/db/organizations';
+import type { UpdateOrganizationInput } from '$lib/types';
+
+interface OrgUpdateBody {
+	language?: string | null;
+	locale?: string | null;
+	timezone?: string | null;
+}
+
+export async function GET(event: RequestEvent) {
+	const { params, platform, cookies, locals } = event;
+	if (!platform) throw error(500, 'Platform not available');
+	const db = platform.env.DB;
+
+	// Require admin role
+	const member = await getAuthenticatedMember(db, cookies);
+	assertAdmin(member);
+
+	// Security: verify params.id matches current org
+	if (params.id !== locals.org.id) {
+		throw error(403, 'Cannot view other organizations');
+	}
+
+	const org = await getOrganizationById(db, params.id);
+	if (!org) {
+		throw error(404, 'Organization not found');
+	}
+
+	return json(org);
+}
+
+export async function PATCH(event: RequestEvent) {
+	const { params, request, platform, cookies, locals } = event;
+	if (!platform) throw error(500, 'Platform not available');
+	const db = platform.env.DB;
+
+	// Require admin role
+	const member = await getAuthenticatedMember(db, cookies);
+	assertAdmin(member);
+
+	// Security: verify params.id matches current org
+	if (params.id !== locals.org.id) {
+		throw error(403, 'Cannot update other organizations');
+	}
+
+	const body = (await request.json()) as OrgUpdateBody;
+
+	// Build update input with proper types
+	const updateInput: UpdateOrganizationInput = {};
+	if ('language' in body) updateInput.language = body.language;
+	if ('locale' in body) updateInput.locale = body.locale;
+	if ('timezone' in body) updateInput.timezone = body.timezone;
+
+	// Update organization with i18n fields
+	const updated = await updateOrganization(db, params.id!, updateInput);
+
+	if (!updated) {
+		throw error(404, 'Organization not found');
+	}
+
+	return json(updated);
+}

--- a/apps/vault/src/routes/settings/+page.server.ts
+++ b/apps/vault/src/routes/settings/+page.server.ts
@@ -3,6 +3,7 @@ import { getAuthenticatedMember, assertAdmin } from '$lib/server/auth/middleware
 import { getAllSettings } from '$lib/server/db/settings';
 import { getAllVoicesWithCounts } from '$lib/server/db/voices';
 import { getAllSectionsWithCounts } from '$lib/server/db/sections';
+import { getOrganizationById } from '$lib/server/db/organizations';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ platform, cookies, locals }) => {
@@ -15,16 +16,18 @@ export const load: PageServerLoad = async ({ platform, cookies, locals }) => {
 
 	const orgId = locals.org.id;
 
-	// Load settings, voices (with counts), and sections (with counts)
-	const [settings, voices, sections] = await Promise.all([
+	// Load settings, voices (with counts), sections (with counts), and organization
+	const [settings, voices, sections, organization] = await Promise.all([
 		getAllSettings(db),
 		getAllVoicesWithCounts(db),
-		getAllSectionsWithCounts(db, orgId)
+		getAllSectionsWithCounts(db, orgId),
+		getOrganizationById(db, orgId)
 	]);
 
 	return {
 		settings,
 		voices,
-		sections
+		sections,
+		organization
 	};
 };

--- a/apps/vault/src/tests/routes/api/organizations.spec.ts
+++ b/apps/vault/src/tests/routes/api/organizations.spec.ts
@@ -1,0 +1,397 @@
+// Tests for /api/organizations/[id] endpoint (Issue #185)
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { RequestEvent } from '@sveltejs/kit';
+import type { Organization } from '$lib/types';
+
+// Mock SvelteKit error function
+vi.mock('@sveltejs/kit', async () => {
+	const actual = await vi.importActual('@sveltejs/kit');
+	return {
+		...actual,
+		error: (status: number, message: string) => {
+			const err = new Error(message);
+			(err as any).status = status;
+			throw err;
+		}
+	};
+});
+
+// Mock database
+function createMockDb(config: {
+	members?: Map<string, any>;
+	organizations?: Map<string, any>;
+} = {}) {
+	const members = config.members ?? new Map();
+	const organizations = config.organizations ?? new Map();
+
+	return {
+		prepare: (query: string) => {
+			const statement = {
+				_params: [] as unknown[],
+				bind: (...params: unknown[]) => {
+					statement._params = params;
+					return statement;
+				},
+				first: async () => {
+					// Member lookup
+					if (query.includes('FROM members WHERE id')) {
+						const id = statement._params?.[0] as string;
+						const memberData = members.get(id);
+						if (!memberData) return null;
+						return {
+							id: memberData.id,
+							email_id: memberData.email_id,
+							name: memberData.name,
+							nickname: memberData.nickname ?? null,
+							email_contact: memberData.email_contact ?? null,
+							invited_by: memberData.invited_by ?? null,
+							joined_at: memberData.joined_at ?? new Date().toISOString()
+						};
+					}
+					// Organization lookup
+					if (query.includes('FROM organizations WHERE id')) {
+						const id = statement._params?.[0] as string;
+						const org = organizations.get(id);
+						return org ?? null;
+					}
+					return null;
+				},
+				all: async () => {
+					// Member roles lookup
+					if (query.includes('FROM member_roles')) {
+						const memberId = statement._params?.[0] as string;
+						const member = members.get(memberId);
+						if (member) {
+							const results = member.roles.map((role: string) => ({ role }));
+							return { results };
+						}
+					}
+					return { results: [] };
+				},
+				run: async () => {
+					// Update organization
+					if (query.includes('UPDATE organizations SET')) {
+						const id = statement._params?.[statement._params.length - 1] as string;
+						const org = organizations.get(id);
+						if (!org) return { meta: { changes: 0 } };
+
+						// Parse which fields are being updated
+						let paramIndex = 0;
+						if (query.includes('language = ?')) {
+							org.language = statement._params[paramIndex++];
+						}
+						if (query.includes('locale = ?')) {
+							org.locale = statement._params[paramIndex++];
+						}
+						if (query.includes('timezone = ?')) {
+							org.timezone = statement._params[paramIndex++];
+						}
+
+						return { meta: { changes: 1 } };
+					}
+					return { meta: { changes: 0 } };
+				}
+			};
+			return statement;
+		}
+	};
+}
+
+function createMockCookies(memberId: string | null) {
+	return {
+		get: (name: string) => (name === 'member_id' ? memberId : null),
+		set: vi.fn(),
+		delete: vi.fn(),
+		serialize: vi.fn(),
+		getAll: vi.fn()
+	};
+}
+
+function createAdminMember(id: string = 'admin-123') {
+	return {
+		id,
+		email_id: 'admin@test.com',
+		name: 'Admin User',
+		roles: ['admin']
+	};
+}
+
+function createOwnerMember(id: string = 'owner-123') {
+	return {
+		id,
+		email_id: 'owner@test.com',
+		name: 'Owner User',
+		roles: ['owner']
+	};
+}
+
+function createRegularMember(id: string = 'member-123') {
+	return {
+		id,
+		email_id: 'member@test.com',
+		name: 'Regular User',
+		roles: []
+	};
+}
+
+function createOrganization(id: string = 'org-123'): {
+	id: string;
+	name: string;
+	subdomain: string;
+	type: string;
+	contact_email: string;
+	created_at: string;
+	language: string | null;
+	locale: string | null;
+	timezone: string | null;
+} {
+	return {
+		id,
+		name: 'Test Choir',
+		subdomain: 'test',
+		type: 'collective',
+		contact_email: 'choir@test.com',
+		created_at: new Date().toISOString(),
+		language: null,
+		locale: null,
+		timezone: null
+	};
+}
+
+describe('PATCH /api/organizations/[id]', () => {
+	it('updates organization i18n settings for admin', async () => {
+		const admin = createAdminMember();
+		const org = createOrganization('org-123');
+		const members = new Map([[admin.id, admin]]);
+		const organizations = new Map([[org.id, org]]);
+
+		const { PATCH } = await import('$lib/../routes/api/organizations/[id]/+server');
+
+		const event = {
+			params: { id: 'org-123' },
+			request: new Request('http://localhost/api/organizations/org-123', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					language: 'et',
+					locale: 'et-EE',
+					timezone: 'Europe/Tallinn'
+				})
+			}),
+			platform: { env: { DB: createMockDb({ members, organizations }) } },
+			cookies: createMockCookies(admin.id),
+			locals: { org: { id: 'org-123' } }
+		} as unknown as RequestEvent;
+
+		const response = await PATCH(event);
+		const data = await response.json() as Organization;
+
+		expect(response.status).toBe(200);
+		expect(data.language).toBe('et');
+		expect(data.locale).toBe('et-EE');
+		expect(data.timezone).toBe('Europe/Tallinn');
+	});
+
+	it('updates organization i18n settings for owner', async () => {
+		const owner = createOwnerMember();
+		const org = createOrganization('org-123');
+		const members = new Map([[owner.id, owner]]);
+		const organizations = new Map([[org.id, org]]);
+
+		const { PATCH } = await import('$lib/../routes/api/organizations/[id]/+server');
+
+		const event = {
+			params: { id: 'org-123' },
+			request: new Request('http://localhost/api/organizations/org-123', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					language: 'en',
+					locale: 'en-GB',
+					timezone: 'Europe/London'
+				})
+			}),
+			platform: { env: { DB: createMockDb({ members, organizations }) } },
+			cookies: createMockCookies(owner.id),
+			locals: { org: { id: 'org-123' } }
+		} as unknown as RequestEvent;
+
+		const response = await PATCH(event);
+		const data = await response.json() as Organization;
+
+		expect(response.status).toBe(200);
+		expect(data.language).toBe('en');
+	});
+
+	it('allows setting values to null (system default)', async () => {
+		const admin = createAdminMember();
+		const org = createOrganization('org-123');
+		org.language = 'et';
+		org.locale = 'et-EE';
+		org.timezone = 'Europe/Tallinn';
+
+		const members = new Map([[admin.id, admin]]);
+		const organizations = new Map([[org.id, org]]);
+
+		const { PATCH } = await import('$lib/../routes/api/organizations/[id]/+server');
+
+		const event = {
+			params: { id: 'org-123' },
+			request: new Request('http://localhost/api/organizations/org-123', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					language: null,
+					locale: null,
+					timezone: null
+				})
+			}),
+			platform: { env: { DB: createMockDb({ members, organizations }) } },
+			cookies: createMockCookies(admin.id),
+			locals: { org: { id: 'org-123' } }
+		} as unknown as RequestEvent;
+
+		const response = await PATCH(event);
+		const data = await response.json() as Organization;
+
+		expect(response.status).toBe(200);
+		expect(data.language).toBeNull();
+		expect(data.locale).toBeNull();
+		expect(data.timezone).toBeNull();
+	});
+
+	it('rejects non-admin users with 403', async () => {
+		const member = createRegularMember();
+		const org = createOrganization('org-123');
+		const members = new Map([[member.id, member]]);
+		const organizations = new Map([[org.id, org]]);
+
+		const { PATCH } = await import('$lib/../routes/api/organizations/[id]/+server');
+
+		const event = {
+			params: { id: 'org-123' },
+			request: new Request('http://localhost/api/organizations/org-123', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ language: 'et' })
+			}),
+			platform: { env: { DB: createMockDb({ members, organizations }) } },
+			cookies: createMockCookies(member.id),
+			locals: { org: { id: 'org-123' } }
+		} as unknown as RequestEvent;
+
+		await expect(PATCH(event)).rejects.toThrow();
+	});
+
+	it('rejects unauthenticated requests with 401', async () => {
+		const org = createOrganization('org-123');
+		const organizations = new Map([[org.id, org]]);
+
+		const { PATCH } = await import('$lib/../routes/api/organizations/[id]/+server');
+
+		const event = {
+			params: { id: 'org-123' },
+			request: new Request('http://localhost/api/organizations/org-123', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ language: 'et' })
+			}),
+			platform: { env: { DB: createMockDb({ organizations }) } },
+			cookies: createMockCookies(null),
+			locals: { org: { id: 'org-123' } }
+		} as unknown as RequestEvent;
+
+		await expect(PATCH(event)).rejects.toThrow();
+	});
+
+	it('rejects updates to other organizations with 403', async () => {
+		const admin = createAdminMember();
+		const org = createOrganization('org-123');
+		const members = new Map([[admin.id, admin]]);
+		const organizations = new Map([[org.id, org]]);
+
+		const { PATCH } = await import('$lib/../routes/api/organizations/[id]/+server');
+
+		// Try to update org-456 while logged into org-123
+		const event = {
+			params: { id: 'org-456' }, // Different org!
+			request: new Request('http://localhost/api/organizations/org-456', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ language: 'et' })
+			}),
+			platform: { env: { DB: createMockDb({ members, organizations }) } },
+			cookies: createMockCookies(admin.id),
+			locals: { org: { id: 'org-123' } } // Current org is different
+		} as unknown as RequestEvent;
+
+		await expect(PATCH(event)).rejects.toThrow('Cannot update other organizations');
+	});
+});
+
+describe('GET /api/organizations/[id]', () => {
+	it('returns organization for admin', async () => {
+		const admin = createAdminMember();
+		const org = createOrganization('org-123');
+		org.language = 'et';
+		org.locale = 'et-EE';
+		org.timezone = 'Europe/Tallinn';
+
+		const members = new Map([[admin.id, admin]]);
+		const organizations = new Map([[org.id, org]]);
+
+		const { GET } = await import('$lib/../routes/api/organizations/[id]/+server');
+
+		const event = {
+			params: { id: 'org-123' },
+			platform: { env: { DB: createMockDb({ members, organizations }) } },
+			cookies: createMockCookies(admin.id),
+			locals: { org: { id: 'org-123' } }
+		} as unknown as RequestEvent;
+
+		const response = await GET(event);
+		const data = await response.json() as Organization;
+
+		expect(response.status).toBe(200);
+		expect(data.id).toBe('org-123');
+		expect(data.language).toBe('et');
+		expect(data.locale).toBe('et-EE');
+		expect(data.timezone).toBe('Europe/Tallinn');
+	});
+
+	it('rejects non-admin users with 403', async () => {
+		const member = createRegularMember();
+		const org = createOrganization('org-123');
+		const members = new Map([[member.id, member]]);
+		const organizations = new Map([[org.id, org]]);
+
+		const { GET } = await import('$lib/../routes/api/organizations/[id]/+server');
+
+		const event = {
+			params: { id: 'org-123' },
+			platform: { env: { DB: createMockDb({ members, organizations }) } },
+			cookies: createMockCookies(member.id),
+			locals: { org: { id: 'org-123' } }
+		} as unknown as RequestEvent;
+
+		await expect(GET(event)).rejects.toThrow();
+	});
+
+	it('rejects viewing other organizations with 403', async () => {
+		const admin = createAdminMember();
+		const org = createOrganization('org-123');
+		const members = new Map([[admin.id, admin]]);
+		const organizations = new Map([[org.id, org]]);
+
+		const { GET } = await import('$lib/../routes/api/organizations/[id]/+server');
+
+		const event = {
+			params: { id: 'org-456' }, // Different org!
+			platform: { env: { DB: createMockDb({ members, organizations }) } },
+			cookies: createMockCookies(admin.id),
+			locals: { org: { id: 'org-123' } }
+		} as unknown as RequestEvent;
+
+		await expect(GET(event)).rejects.toThrow('Cannot view other organizations');
+	});
+});


### PR DESCRIPTION
## Summary

Implements issue #185 - Organization settings UI for language/locale/timezone configuration.

## Changes

### API Endpoint
- **New**: `PATCH /api/organizations/[id]` - Update org i18n settings
- **New**: `GET /api/organizations/[id]` - Fetch org details
- Security: Verifies `params.id === locals.org.id` to prevent cross-org access
- Admin-only access via `assertAdmin()` middleware

### Settings Page UI
- Added **Organization Settings** card to `/settings` page with:
  - Language dropdown (ISO 639-1 codes: en, et, de, etc.)
  - Locale dropdown (BCP 47 codes: en-US, et-EE, etc.)
  - Timezone dropdown (IANA zones: Europe/Tallinn, UTC, etc.)
- Separate save buttons for vault vs org settings (per design spec)
- Empty string → `null` (system default) conversion

### Tests
- 9 comprehensive tests for the new API endpoint:
  - Admin can update i18n settings
  - Owner can update i18n settings
  - Setting values to null (system default) works
  - Non-admin users rejected with 403
  - Unauthenticated requests rejected with 401
  - Cross-org updates rejected with 403
  - GET endpoint tests (admin access, rejections)

## Testing

```bash
# All 919 vault tests pass
pnpm test

# Type checks pass
pnpm check
```

## Part of Epic #183 (i18n preferences)

Closes #185