### PR TITLE
feat(vault): Member preferences UI for i18n settings

### DIFF
--- a/apps/vault/src/routes/api/profile/preferences/+server.ts
+++ b/apps/vault/src/routes/api/profile/preferences/+server.ts
@@ -1,0 +1,45 @@
+// API endpoint for member i18n preferences (Issue #186)
+// GET /api/profile/preferences - Get member preferences
+// PATCH /api/profile/preferences - Update member preferences
+
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getAuthenticatedMember } from '$lib/server/auth/middleware';
+import { getMemberPreferences, setMemberPreferences } from '$lib/server/db/member-preferences';
+import type { UpdateMemberPreferencesInput } from '$lib/types';
+
+interface UpdatePreferencesBody {
+	language?: string | null;
+	locale?: string | null;
+	timezone?: string | null;
+}
+
+/** Parse request body into UpdateMemberPreferencesInput */
+function parseUpdateInput(body: UpdatePreferencesBody): UpdateMemberPreferencesInput {
+	const input: UpdateMemberPreferencesInput = {};
+	if ('language' in body) input.language = body.language;
+	if ('locale' in body) input.locale = body.locale;
+	if ('timezone' in body) input.timezone = body.timezone;
+	return input;
+}
+
+export const GET: RequestHandler = async ({ platform, cookies }) => {
+	const db = platform?.env?.DB;
+	if (!db) throw error(500, 'Database not available');
+
+	const member = await getAuthenticatedMember(db, cookies);
+	const prefs = await getMemberPreferences(db, member.id);
+	
+	return json(prefs);
+};
+
+export const PATCH: RequestHandler = async ({ request, platform, cookies }) => {
+	const db = platform?.env?.DB;
+	if (!db) throw error(500, 'Database not available');
+
+	const member = await getAuthenticatedMember(db, cookies);
+	const body = (await request.json()) as UpdatePreferencesBody;
+	const updated = await setMemberPreferences(db, member.id, parseUpdateInput(body));
+	
+	return json(updated);
+};

--- a/apps/vault/src/tests/routes/api/profile-preferences.spec.ts
+++ b/apps/vault/src/tests/routes/api/profile-preferences.spec.ts
@@ -1,0 +1,219 @@
+// Tests for /api/profile/preferences endpoint (Issue #186)
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RequestEvent } from '@sveltejs/kit';
+import type { MemberPreferences } from '$lib/types';
+
+// Mock SvelteKit error/json functions
+vi.mock('@sveltejs/kit', async () => {
+	const actual = await vi.importActual('@sveltejs/kit');
+	return {
+		...actual,
+		error: (status: number, message: string) => {
+			const err = new Error(message);
+			(err as any).status = status;
+			throw err;
+		},
+		json: (data: any, options?: any) =>
+			new Response(JSON.stringify(data), {
+				status: options?.status || 200,
+				headers: { 'content-type': 'application/json' }
+			})
+	};
+});
+
+// Mock authenticated member
+const mockMember = {
+	id: 'member-123',
+	email_id: 'user@test.com',
+	email_contact: null,
+	name: 'Test User',
+	nickname: null,
+	roles: [],
+	voices: [],
+	sections: [],
+	invited_by: null,
+	joined_at: '2024-01-01T00:00:00Z'
+};
+
+// Mock preferences
+const mockPreferences: MemberPreferences = {
+	memberId: 'member-123',
+	language: 'et',
+	locale: 'et-EE',
+	timezone: 'Europe/Tallinn',
+	updatedAt: '2024-01-15T00:00:00Z'
+};
+
+// Mock auth middleware
+vi.mock('$lib/server/auth/middleware', () => ({
+	getAuthenticatedMember: vi.fn()
+}));
+
+// Mock member preferences DB functions
+vi.mock('$lib/server/db/member-preferences', () => ({
+	getMemberPreferences: vi.fn(),
+	setMemberPreferences: vi.fn()
+}));
+
+// Helper to create mock request event
+function createMockEvent(
+	method: 'GET' | 'PATCH',
+	body?: any,
+	isAuthenticated: boolean = true
+): RequestEvent<any, any> {
+	const request = method === 'GET'
+		? new Request('http://localhost/api/profile/preferences', { method })
+		: new Request('http://localhost/api/profile/preferences', {
+				method,
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body)
+		  });
+
+	return {
+		route: { id: '/api/profile/preferences' },
+		request,
+		platform: {
+			env: { DB: {} }
+		},
+		cookies: {
+			get: vi.fn(() => (isAuthenticated ? mockMember.id : undefined))
+		},
+		locals: {}
+	} as any;
+}
+
+describe('GET /api/profile/preferences', () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		const { getAuthenticatedMember } = await import('$lib/server/auth/middleware');
+		vi.mocked(getAuthenticatedMember).mockResolvedValue(mockMember);
+	});
+
+	it('returns member preferences for authenticated user', async () => {
+		const { getMemberPreferences } = await import('$lib/server/db/member-preferences');
+		vi.mocked(getMemberPreferences).mockResolvedValue(mockPreferences);
+
+		const { GET } = await import('$lib/../routes/api/profile/preferences/+server');
+		const event = createMockEvent('GET');
+		const response = await GET(event);
+
+		expect(response.status).toBe(200);
+		const data = await response.json() as MemberPreferences;
+		expect(data.language).toBe('et');
+		expect(data.locale).toBe('et-EE');
+		expect(data.timezone).toBe('Europe/Tallinn');
+	});
+
+	it('returns null when no preferences exist', async () => {
+		const { getMemberPreferences } = await import('$lib/server/db/member-preferences');
+		vi.mocked(getMemberPreferences).mockResolvedValue(null);
+
+		const { GET } = await import('$lib/../routes/api/profile/preferences/+server');
+		const event = createMockEvent('GET');
+		const response = await GET(event);
+
+		expect(response.status).toBe(200);
+		const data = await response.json();
+		expect(data).toBeNull();
+	});
+
+	it('rejects unauthenticated requests with 401', async () => {
+		const { getAuthenticatedMember } = await import('$lib/server/auth/middleware');
+		vi.mocked(getAuthenticatedMember).mockRejectedValue(Object.assign(new Error('Not authenticated'), { status: 401 }));
+
+		const { GET } = await import('$lib/../routes/api/profile/preferences/+server');
+		const event = createMockEvent('GET', undefined, false);
+
+		await expect(GET(event)).rejects.toThrow();
+	});
+});
+
+describe('PATCH /api/profile/preferences', () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		const { getAuthenticatedMember } = await import('$lib/server/auth/middleware');
+		vi.mocked(getAuthenticatedMember).mockResolvedValue(mockMember);
+	});
+
+	it('updates member preferences successfully', async () => {
+		const { setMemberPreferences } = await import('$lib/server/db/member-preferences');
+		const updatedPrefs: MemberPreferences = {
+			memberId: 'member-123',
+			language: 'en',
+			locale: 'en-US',
+			timezone: 'America/New_York',
+			updatedAt: '2024-01-20T00:00:00Z'
+		};
+		vi.mocked(setMemberPreferences).mockResolvedValue(updatedPrefs);
+
+		const { PATCH } = await import('$lib/../routes/api/profile/preferences/+server');
+		const event = createMockEvent('PATCH', {
+			language: 'en',
+			locale: 'en-US',
+			timezone: 'America/New_York'
+		});
+		const response = await PATCH(event);
+
+		expect(response.status).toBe(200);
+		const data = await response.json() as MemberPreferences;
+		expect(data.language).toBe('en');
+		expect(data.locale).toBe('en-US');
+		expect(data.timezone).toBe('America/New_York');
+	});
+
+	it('allows setting values to null (use defaults)', async () => {
+		const { setMemberPreferences } = await import('$lib/server/db/member-preferences');
+		const clearedPrefs: MemberPreferences = {
+			memberId: 'member-123',
+			language: null,
+			locale: null,
+			timezone: null,
+			updatedAt: '2024-01-20T00:00:00Z'
+		};
+		vi.mocked(setMemberPreferences).mockResolvedValue(clearedPrefs);
+
+		const { PATCH } = await import('$lib/../routes/api/profile/preferences/+server');
+		const event = createMockEvent('PATCH', {
+			language: null,
+			locale: null,
+			timezone: null
+		});
+		const response = await PATCH(event);
+
+		expect(response.status).toBe(200);
+		const data = await response.json() as MemberPreferences;
+		expect(data.language).toBeNull();
+		expect(data.locale).toBeNull();
+		expect(data.timezone).toBeNull();
+	});
+
+	it('allows partial updates', async () => {
+		const { setMemberPreferences } = await import('$lib/server/db/member-preferences');
+		const partialUpdate: MemberPreferences = {
+			memberId: 'member-123',
+			language: 'de',
+			locale: 'et-EE', // unchanged
+			timezone: 'Europe/Tallinn', // unchanged
+			updatedAt: '2024-01-20T00:00:00Z'
+		};
+		vi.mocked(setMemberPreferences).mockResolvedValue(partialUpdate);
+
+		const { PATCH } = await import('$lib/../routes/api/profile/preferences/+server');
+		const event = createMockEvent('PATCH', { language: 'de' }); // only language
+		const response = await PATCH(event);
+
+		expect(response.status).toBe(200);
+		const data = await response.json() as MemberPreferences;
+		expect(data.language).toBe('de');
+	});
+
+	it('rejects unauthenticated requests with 401', async () => {
+		const { getAuthenticatedMember } = await import('$lib/server/auth/middleware');
+		vi.mocked(getAuthenticatedMember).mockRejectedValue(Object.assign(new Error('Not authenticated'), { status: 401 }));
+
+		const { PATCH } = await import('$lib/../routes/api/profile/preferences/+server');
+		const event = createMockEvent('PATCH', { language: 'en' }, false);
+
+		await expect(PATCH(event)).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

Implements issue #186 - Member profile preferences for language/locale/timezone.

## Changes

### API Endpoint
- **GET /api/profile/preferences** - Returns member's i18n preferences
- **PATCH /api/profile/preferences** - Updates member preferences (null = use org default)

### Profile Page
- Added "Language & Regional Preferences" card on own profile page
- Shows effective value with source indicator:
  - "(your preference)" - explicitly set by member
  - "(organization default)" - inherited from org settings
  - "(system default)" - fallback when nothing configured
- Dropdown default shows org value: "Use organization default (en)"

### Resolution Cascade
Uses `resolvePreferences()` to determine effective values:
1. Member preferences (if set)
2. Organization settings (if configured)
3. System defaults (en, en-US, UTC)

## Technical Details

- 7 new tests for API endpoint
- Uses existing `getMemberPreferences()` / `setMemberPreferences()` from #184
- Uses `resolvePreferences()` from #187

## Screenshot

The card only appears on your own profile page, showing dropdowns for:
- Language (10 options)
- Date & Number Format (11 locales)
- Timezone (14 options)

Each field shows its effective value and source below the dropdown.

## Part of Epic #183

- ✅ #184 - Database tables
- ✅ #187 - Resolution cascade
- ✅ #185 - Organization settings UI
- ✅ #186 - Member preferences UI (this PR)

Closes #186