### PR TITLE
refactor: Send admin notifications via Registry (#202)

### DIFF
--- a/apps/registry/src/app.d.ts
+++ b/apps/registry/src/app.d.ts
@@ -9,6 +9,9 @@ declare global {
 		interface Platform {
 			env: {
 				DB: D1Database;
+				RESEND_API_KEY?: string;
+				ADMIN_EMAIL?: string;
+				NOTIFY_API_KEY?: string;
 			};
 			context: {
 				waitUntil(promise: Promise<unknown>): void;

--- a/apps/registry/src/routes/api/notify/registration/+server.ts
+++ b/apps/registry/src/routes/api/notify/registration/+server.ts
@@ -1,0 +1,112 @@
+// Admin notification endpoint for new organization registrations
+// POST /api/notify/registration
+// Issue #202 - Called by Vault when new org is registered
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { sendAdminNotification, type RegistrationNotificationData } from '$lib/server/email';
+
+interface CloudflarePlatform {
+	env: {
+		RESEND_API_KEY?: string;
+		ADMIN_EMAIL?: string;
+		NOTIFY_API_KEY?: string;
+	};
+}
+
+interface NotificationRequest extends RegistrationNotificationData {
+	apiKey: string;
+}
+
+// CORS headers for cross-origin requests from vaults
+const CORS_HEADERS = {
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'POST, OPTIONS',
+	'Access-Control-Allow-Headers': 'Content-Type'
+};
+
+function corsJson(data: unknown, init?: ResponseInit) {
+	return json(data, {
+		...init,
+		headers: { ...CORS_HEADERS, ...init?.headers }
+	});
+}
+
+// Handle preflight requests
+export const OPTIONS: RequestHandler = async () => {
+	return new Response(null, { status: 204, headers: CORS_HEADERS });
+};
+
+const REQUIRED_FIELDS = ['orgName', 'subdomain', 'contactEmail', 'memberName', 'memberEmail', 'orgId'] as const;
+
+function validateRequest(body: unknown): { data?: NotificationRequest; error?: string } {
+	const req = body as Partial<NotificationRequest>;
+
+	if (!req.apiKey || typeof req.apiKey !== 'string') {
+		return { error: 'Missing API key' };
+	}
+
+	for (const field of REQUIRED_FIELDS) {
+		if (!req[field] || typeof req[field] !== 'string') {
+			return { error: `Missing required field: ${field}` };
+		}
+	}
+
+	return { data: req as NotificationRequest };
+}
+
+export const POST: RequestHandler = async ({ request, platform }) => {
+	const env = (platform as CloudflarePlatform | undefined)?.env;
+
+	// Check service configuration
+	if (!env?.RESEND_API_KEY) {
+		return corsJson({ success: false, error: 'Email service unavailable' }, { status: 500 });
+	}
+	if (!env.ADMIN_EMAIL) {
+		return corsJson({ success: false, error: 'Admin email not configured' }, { status: 500 });
+	}
+	if (!env.NOTIFY_API_KEY) {
+		return corsJson({ success: false, error: 'Notification service not configured' }, { status: 500 });
+	}
+
+	// Parse request body
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return corsJson({ success: false, error: 'Invalid JSON' }, { status: 400 });
+	}
+
+	// Validate request
+	const validation = validateRequest(body);
+	if (validation.error) {
+		// Check if it's an auth error
+		if (validation.error.includes('API key')) {
+			return corsJson({ success: false, error: validation.error }, { status: 401 });
+		}
+		return corsJson({ success: false, error: validation.error }, { status: 400 });
+	}
+
+	const { apiKey, orgName, subdomain, contactEmail, memberName, memberEmail, orgId } = validation.data!;
+
+	// Verify API key
+	if (apiKey !== env.NOTIFY_API_KEY) {
+		return corsJson({ success: false, error: 'Invalid API key' }, { status: 401 });
+	}
+
+	// Send notification email
+	const result = await sendAdminNotification(env.RESEND_API_KEY, env.ADMIN_EMAIL, {
+		orgName,
+		subdomain,
+		contactEmail,
+		memberName,
+		memberEmail,
+		orgId
+	});
+
+	if (!result.success) {
+		return corsJson({ success: false, error: 'Failed to send notification email' }, { status: 500 });
+	}
+
+	return corsJson({ success: true, emailId: result.emailId });
+};

--- a/apps/registry/src/tests/routes/api/notify/registration.spec.ts
+++ b/apps/registry/src/tests/routes/api/notify/registration.spec.ts
@@ -1,0 +1,280 @@
+// Tests for POST /api/notify/registration endpoint
+// Issue #202 - Admin notification for new organization registrations
+// TDD: Tests written first
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST, OPTIONS } from '../../../../routes/api/notify/registration/+server';
+
+// Mock the email service
+vi.mock('../../../../lib/server/email', () => ({
+	sendAdminNotification: vi.fn().mockResolvedValue({ success: true, emailId: 'email_123' })
+}));
+
+import { sendAdminNotification } from '../../../../lib/server/email';
+
+interface ApiResponse {
+	success: boolean;
+	message?: string;
+	error?: string;
+	emailId?: string;
+}
+
+interface RegistrationPayload {
+	orgName?: string;
+	subdomain?: string;
+	contactEmail?: string;
+	memberName?: string;
+	memberEmail?: string;
+	orgId?: string;
+	apiKey?: string;
+}
+
+function createMockRequest(body: RegistrationPayload): Request {
+	return new Request('http://localhost/api/notify/registration', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
+	});
+}
+
+const validPayload: RegistrationPayload = {
+	orgName: 'City Chamber Choir',
+	subdomain: 'citychamber',
+	contactEmail: 'admin@citychoir.org',
+	memberName: 'John Director',
+	memberEmail: 'john@example.com',
+	orgId: 'org_abc123',
+	apiKey: 'test-notify-key'
+};
+
+describe('POST /api/notify/registration', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('CORS', () => {
+		it('should handle OPTIONS preflight request', async () => {
+			const response = await OPTIONS({} as Parameters<typeof OPTIONS>[0]);
+
+			expect(response.status).toBe(204);
+			expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+			expect(response.headers.get('Access-Control-Allow-Methods')).toContain('POST');
+		});
+
+		it('should include CORS headers in POST response', async () => {
+			const response = await POST({
+				request: createMockRequest(validPayload),
+				platform: {
+					env: {
+						RESEND_API_KEY: 'test-key',
+						ADMIN_EMAIL: 'admin@polyphony.uk',
+						NOTIFY_API_KEY: 'test-notify-key'
+					}
+				}
+			} as unknown as Parameters<typeof POST>[0]);
+
+			expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+		});
+	});
+
+	describe('Authentication', () => {
+		it('should reject missing API key', async () => {
+			const payload = { ...validPayload };
+			delete payload.apiKey;
+
+			const response = await POST({
+				request: createMockRequest(payload),
+				platform: {
+					env: {
+						RESEND_API_KEY: 'test-key',
+						ADMIN_EMAIL: 'admin@polyphony.uk',
+						NOTIFY_API_KEY: 'test-notify-key'
+					}
+				}
+			} as unknown as Parameters<typeof POST>[0]);
+
+			expect(response.status).toBe(401);
+			const data = (await response.json()) as ApiResponse;
+			expect(data.success).toBe(false);
+			expect(data.error).toContain('API key');
+		});
+
+		it('should reject invalid API key', async () => {
+			const response = await POST({
+				request: createMockRequest({ ...validPayload, apiKey: 'wrong-key' }),
+				platform: {
+					env: {
+						RESEND_API_KEY: 'test-key',
+						ADMIN_EMAIL: 'admin@polyphony.uk',
+						NOTIFY_API_KEY: 'test-notify-key'
+					}
+				}
+			} as unknown as Parameters<typeof POST>[0]);
+
+			expect(response.status).toBe(401);
+			const data = (await response.json()) as ApiResponse;
+			expect(data.success).toBe(false);
+			expect(data.error).toContain('Invalid');
+		});
+	});
+
+	describe('Validation', () => {
+		it('should reject missing orgName', async () => {
+			const payload = { ...validPayload };
+			delete payload.orgName;
+
+			const response = await POST({
+				request: createMockRequest(payload),
+				platform: {
+					env: {
+						RESEND_API_KEY: 'test-key',
+						ADMIN_EMAIL: 'admin@polyphony.uk',
+						NOTIFY_API_KEY: 'test-notify-key'
+					}
+				}
+			} as unknown as Parameters<typeof POST>[0]);
+
+			expect(response.status).toBe(400);
+			const data = (await response.json()) as ApiResponse;
+			expect(data.success).toBe(false);
+			expect(data.error).toContain('orgName');
+		});
+
+		it('should reject missing subdomain', async () => {
+			const payload = { ...validPayload };
+			delete payload.subdomain;
+
+			const response = await POST({
+				request: createMockRequest(payload),
+				platform: {
+					env: {
+						RESEND_API_KEY: 'test-key',
+						ADMIN_EMAIL: 'admin@polyphony.uk',
+						NOTIFY_API_KEY: 'test-notify-key'
+					}
+				}
+			} as unknown as Parameters<typeof POST>[0]);
+
+			expect(response.status).toBe(400);
+			const data = (await response.json()) as ApiResponse;
+			expect(data.success).toBe(false);
+			expect(data.error).toContain('subdomain');
+		});
+
+		it('should reject invalid JSON', async () => {
+			const request = new Request('http://localhost/api/notify/registration', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: 'not json'
+			});
+
+			const response = await POST({
+				request,
+				platform: {
+					env: {
+						RESEND_API_KEY: 'test-key',
+						ADMIN_EMAIL: 'admin@polyphony.uk',
+						NOTIFY_API_KEY: 'test-notify-key'
+					}
+				}
+			} as unknown as Parameters<typeof POST>[0]);
+
+			expect(response.status).toBe(400);
+			const data = (await response.json()) as ApiResponse;
+			expect(data.success).toBe(false);
+			expect(data.error).toContain('JSON');
+		});
+	});
+
+	describe('Email sending', () => {
+		it('should send notification email with all fields', async () => {
+			const response = await POST({
+				request: createMockRequest(validPayload),
+				platform: {
+					env: {
+						RESEND_API_KEY: 'test-key',
+						ADMIN_EMAIL: 'admin@polyphony.uk',
+						NOTIFY_API_KEY: 'test-notify-key'
+					}
+				}
+			} as unknown as Parameters<typeof POST>[0]);
+
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as ApiResponse;
+			expect(data.success).toBe(true);
+
+			expect(sendAdminNotification).toHaveBeenCalledOnce();
+			expect(sendAdminNotification).toHaveBeenCalledWith(
+				'test-key',
+				'admin@polyphony.uk',
+				{
+					orgName: 'City Chamber Choir',
+					subdomain: 'citychamber',
+					contactEmail: 'admin@citychoir.org',
+					memberName: 'John Director',
+					memberEmail: 'john@example.com',
+					orgId: 'org_abc123'
+				}
+			);
+		});
+
+		it('should return 500 if email service unavailable', async () => {
+			const response = await POST({
+				request: createMockRequest(validPayload),
+				platform: {
+					env: {
+						// Missing RESEND_API_KEY
+						ADMIN_EMAIL: 'admin@polyphony.uk',
+						NOTIFY_API_KEY: 'test-notify-key'
+					}
+				}
+			} as unknown as Parameters<typeof POST>[0]);
+
+			expect(response.status).toBe(500);
+			const data = (await response.json()) as ApiResponse;
+			expect(data.success).toBe(false);
+			expect(data.error).toContain('Email service');
+		});
+
+		it('should return 500 if admin email not configured', async () => {
+			const response = await POST({
+				request: createMockRequest(validPayload),
+				platform: {
+					env: {
+						RESEND_API_KEY: 'test-key',
+						// Missing ADMIN_EMAIL
+						NOTIFY_API_KEY: 'test-notify-key'
+					}
+				}
+			} as unknown as Parameters<typeof POST>[0]);
+
+			expect(response.status).toBe(500);
+			const data = (await response.json()) as ApiResponse;
+			expect(data.success).toBe(false);
+			expect(data.error).toContain('Admin email');
+		});
+
+		it('should handle email sending failure gracefully', async () => {
+			vi.mocked(sendAdminNotification).mockResolvedValueOnce({
+				success: false,
+				error: 'Resend API error'
+			});
+
+			const response = await POST({
+				request: createMockRequest(validPayload),
+				platform: {
+					env: {
+						RESEND_API_KEY: 'test-key',
+						ADMIN_EMAIL: 'admin@polyphony.uk',
+						NOTIFY_API_KEY: 'test-notify-key'
+					}
+				}
+			} as unknown as Parameters<typeof POST>[0]);
+
+			expect(response.status).toBe(500);
+			const data = (await response.json()) as ApiResponse;
+			expect(data.success).toBe(false);
+			expect(data.error).toContain('Failed to send');
+		});
+	});
+});

--- a/apps/registry/wrangler.toml
+++ b/apps/registry/wrangler.toml
@@ -7,3 +7,9 @@ pages_build_output_dir = ".svelte-kit/cloudflare"
 binding = "DB"
 database_name = "polyphony-registry-db"
 database_id = "1b804304-94ad-4e32-ade4-9b3c363e3c48"
+
+# Environment variables (use wrangler secret for production)
+# Secrets: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, RESEND_API_KEY, NOTIFY_API_KEY
+
+[vars]
+ADMIN_EMAIL = ""  # Admin email for registration notifications (#202)

--- a/apps/vault/src/app.d.ts
+++ b/apps/vault/src/app.d.ts
@@ -15,9 +15,8 @@ declare global {
 				REGISTRY_OAUTH_URL: string;
 				SESSION_SECRET: string;
 				VAULT_ID: string;
-				// Email notifications (#202)
-				RESEND_API_KEY?: string;
-				ADMIN_EMAIL?: string;
+				// Admin notification via Registry (#202)
+				NOTIFY_API_KEY?: string;
 			};
 			context: {
 				waitUntil(promise: Promise<unknown>): void;

--- a/apps/vault/src/routes/register/+page.server.ts
+++ b/apps/vault/src/routes/register/+page.server.ts
@@ -100,8 +100,8 @@ export const actions: Actions = {
 			// Add owner role for this organization
 			await addMemberRoles(db, member.id, ['owner'], null, org.id);
 
-			// Send admin notification email (graceful failure - don't block registration)
-			// Uses Resend API via RESEND_API_KEY and ADMIN_EMAIL env vars
+			// Send admin notification via Registry (graceful failure - don't block registration)
+			// Registry handles email sending via Resend
 			await sendAdminNotification(
 				{
 					orgName: org.name,
@@ -112,8 +112,8 @@ export const actions: Actions = {
 					orgId: org.id
 				},
 				{
-					resendApiKey: platform.env.RESEND_API_KEY ?? '',
-					adminEmail: platform.env.ADMIN_EMAIL ?? ''
+					registryUrl: platform.env.REGISTRY_OAUTH_URL ?? '',
+					notifyApiKey: platform.env.NOTIFY_API_KEY ?? ''
 				}
 			);
 

--- a/apps/vault/wrangler.toml
+++ b/apps/vault/wrangler.toml
@@ -13,9 +13,8 @@ database_id = "0ecb378b-b9e3-4243-a5e9-9cf4ffe98fd2"
 # See issue #33 for rationale, #34 for future chunked storage support
 
 # Environment variables (use wrangler secret for production)
-# Secrets: REGISTRY_CLIENT_ID, REGISTRY_CLIENT_SECRET, SESSION_SECRET, RESEND_API_KEY
+# Secrets: REGISTRY_CLIENT_ID, REGISTRY_CLIENT_SECRET, SESSION_SECRET, NOTIFY_API_KEY
 
 [vars]
 REGISTRY_OAUTH_URL = "https://polyphony.uk"
 VAULT_ID = "BQ6u9ENTnZk_danhhIbUB"  # Vault identifier (public, appears in JWT aud claim)
-ADMIN_EMAIL = ""  # Set to admin email for registration notifications (#202)


### PR DESCRIPTION
## Summary
Updates #202 - Refactors admin notification to use Registry instead of Vault calling Resend directly.

## Why This Change
The Registry already has Resend configured for magic link authentication. Instead of duplicating that setup in Vault, Vault now calls Registry's API to send admin notifications. This:
- Centralizes email sending in one place (Registry)
- Eliminates need for Vault to have Resend credentials
- Reuses existing infrastructure

## Architecture
```
Before:  Vault → Resend API
After:   Vault → Registry /api/notify/registration → Resend API
```

## Changes

### Registry
- Add `sendAdminNotification()` to `/server/email.ts`
- Add `POST /api/notify/registration` endpoint with API key auth
- Add `ADMIN_EMAIL` (var) and `NOTIFY_API_KEY` (secret) to env
- **11 new tests** for notification endpoint

### Vault
- Rewrite `admin-notification.ts` to call Registry API
- Replace `RESEND_API_KEY`/`ADMIN_EMAIL` with `NOTIFY_API_KEY`
- **7 tests** updated for new implementation

## Setup Required
```bash
# Registry (one-time setup)
wrangler secret put NOTIFY_API_KEY  # Generate secure key
# Edit wrangler.toml: ADMIN_EMAIL = "admin@scoreinstitute.eu"

# Vault
wrangler secret put NOTIFY_API_KEY  # Same key as Registry
```

## Testing
- 101 Registry tests pass (11 new)
- 961 Vault tests pass (7 updated)
- Total: 1082 tests across monorepo