### PR TITLE
feat(registry): Check SSO cookie in auth initiation

### DIFF
--- a/apps/registry/src/tests/routes/auth/init.spec.ts
+++ b/apps/registry/src/tests/routes/auth/init.spec.ts
@@ -1,27 +1,94 @@
 // Test OAuth initiation endpoint
 /// <reference types="@cloudflare/workers-types" />
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET } from '../../../routes/auth/+server.js';
 import type { ErrorResponse } from '../../../lib/types/api.js';
 import type { JWKS } from '@polyphony/shared/crypto';
-import type { TestRequestEvent } from '../../helpers/types.js';
+import { generateKeyPair, exportJWK, exportPKCS8 } from 'jose';
+import { signToken } from '@polyphony/shared/crypto';
+
+// Test key pair - generated once for all tests
+let testPrivateKey: string;
+let testPublicKeyJwk: object;
+
+beforeEach(async () => {
+	// Generate a fresh Ed25519 key pair for testing
+	const keyPair = await generateKeyPair('EdDSA', { crv: 'Ed25519', extractable: true });
+	testPrivateKey = await exportPKCS8(keyPair.privateKey);
+	const jwk = await exportJWK(keyPair.publicKey);
+	jwk.kid = 'test-key-id';
+	testPublicKeyJwk = jwk;
+});
+
+// Type for our GET handler parameters
+interface AuthRequestEvent {
+	url: URL;
+	platform?: {
+		env: {
+			DB: D1Database;
+			API_KEY: string;
+			GOOGLE_CLIENT_ID: string;
+		};
+	};
+	cookies?: {
+		get: (name: string) => string | undefined;
+	};
+}
 
 // Mock D1 database
-const createMockDb = (vaultExists: boolean, callback?: string) => ({
-	prepare: (sql: string) => ({
-		bind: () => ({
-			first: async () =>
-				vaultExists
+const createMockDb = (vaultExists: boolean, callback?: string, includePrivateKey: boolean = false, privateKey?: string) => ({
+	prepare: (sql: string) => {
+		const queryResult = async () => {
+			if (sql.includes('vaults')) {
+				return vaultExists
 					? {
 							id: 'vault-test-id',
 							name: 'Test Vault',
 							callback_url: callback || 'https://vault.example.com/callback',
 							active: 1
 						}
-					: null
-		})
-	})
+					: null;
+			}
+			if (sql.includes('signing_keys') && includePrivateKey) {
+				return {
+					id: 'test-key-id',
+					private_key: privateKey,
+					public_key: JSON.stringify(testPublicKeyJwk)
+				};
+			}
+			return null;
+		};
+		
+		return {
+			// D1 allows calling .first() directly (no bind) or .bind().first()
+			first: queryResult,
+			bind: (...args: unknown[]) => ({
+				first: queryResult
+			})
+		};
+	}
 } as unknown as D1Database);
+
+// Helper to create a valid SSO token
+async function createValidSSOToken(privateKey: string): Promise<string> {
+	return await signToken(
+		{
+			iss: 'https://polyphony.uk',
+			sub: 'user@example.com',
+			aud: 'polyphony-sso',
+			nonce: 'test-nonce',
+			email: 'user@example.com',
+			name: 'Test User',
+			picture: 'https://example.com/photo.jpg'
+		},
+		privateKey
+	);
+}
+
+// Mock cookies helper
+const createMockCookies = (cookieValue?: string) => ({
+	get: (name: string) => (name === 'polyphony_sso' ? cookieValue : undefined)
+});
 
 describe('GET /auth', () => {
 	it('should reject missing vault_id parameter', async () => {
@@ -29,7 +96,7 @@ describe('GET /auth', () => {
 		const response = await GET({
 			url,
 			platform: { env: { DB: createMockDb(false), API_KEY: 'test', GOOGLE_CLIENT_ID: 'test-client-id' } }
-		} satisfies TestRequestEvent);
+		} satisfies AuthRequestEvent);
 
 		expect(response.status).toBe(400);
 		const data = await response.json() as ErrorResponse;
@@ -41,7 +108,7 @@ describe('GET /auth', () => {
 		const response = await GET({
 			url,
 			platform: { env: { DB: createMockDb(true), API_KEY: 'test', GOOGLE_CLIENT_ID: 'test-client-id' } }
-		} satisfies TestRequestEvent);
+		} satisfies AuthRequestEvent);
 
 		expect(response.status).toBe(400);
 		const data = await response.json() as ErrorResponse;
@@ -55,7 +122,7 @@ describe('GET /auth', () => {
 		const response = await GET({
 			url,
 			platform: { env: { DB: createMockDb(false), API_KEY: 'test', GOOGLE_CLIENT_ID: 'test-client-id' } }
-		} satisfies TestRequestEvent);
+		} satisfies AuthRequestEvent);
 
 		expect(response.status).toBe(400);
 		const data = await response.json() as ErrorResponse;
@@ -75,7 +142,7 @@ describe('GET /auth', () => {
 					GOOGLE_CLIENT_ID: 'test-google-client-id'
 				}
 			}
-		} satisfies TestRequestEvent);
+		} satisfies AuthRequestEvent);
 
 		expect(response.status).toBe(400);
 		const data = await response.json() as ErrorResponse;
@@ -97,7 +164,7 @@ describe('GET /auth', () => {
 						GOOGLE_CLIENT_ID: 'test-client-id'
 					}
 				}
-			} satisfies TestRequestEvent);
+			} satisfies AuthRequestEvent);
 			
 			// Should not reach here - redirect throws
 			expect(true).toBe(false);
@@ -110,5 +177,154 @@ describe('GET /auth', () => {
 			expect(location).toContain('response_type=code');
 			expect(location).toContain('scope=openid+email+profile');
 		}
+	});
+
+	// ==========================================================================
+	// SSO Cookie Tests (Issue #209)
+	// ==========================================================================
+	describe('SSO Cookie', () => {
+		it('should skip OAuth and redirect with vault token when valid SSO cookie present', async () => {
+			const ssoToken = await createValidSSOToken(testPrivateKey);
+			const url = new URL(
+				'http://localhost/auth?vault_id=vault-test-id&callback=https://vault.example.com/callback'
+			);
+
+			const response = await GET({
+				url,
+				platform: {
+					env: {
+						DB: createMockDb(true, 'https://vault.example.com/callback', true, testPrivateKey),
+						API_KEY: 'test',
+						GOOGLE_CLIENT_ID: 'test-client-id'
+					}
+				},
+				cookies: createMockCookies(ssoToken)
+			} as unknown as Parameters<typeof GET>[0]);
+
+			// Should return Response (not throw redirect)
+			expect(response.status).toBe(302);
+			const location = response.headers.get('Location');
+			expect(location).toContain('https://vault.example.com/callback');
+			expect(location).toContain('token=');
+			// Should NOT go to Google OAuth
+			expect(location).not.toContain('accounts.google.com');
+		});
+
+		it('should include valid vault JWT in redirect when SSO cookie used', async () => {
+			const ssoToken = await createValidSSOToken(testPrivateKey);
+			const url = new URL(
+				'http://localhost/auth?vault_id=vault-test-id&callback=https://vault.example.com/callback'
+			);
+
+			const response = await GET({
+				url,
+				platform: {
+					env: {
+						DB: createMockDb(true, 'https://vault.example.com/callback', true, testPrivateKey),
+						API_KEY: 'test',
+						GOOGLE_CLIENT_ID: 'test-client-id'
+					}
+				},
+				cookies: createMockCookies(ssoToken)
+			} as unknown as Parameters<typeof GET>[0]);
+
+			const location = response.headers.get('Location')!;
+			const callbackUrl = new URL(location);
+			const vaultToken = callbackUrl.searchParams.get('token')!;
+
+			// Vault token should be a valid JWT (3 parts)
+			const parts = vaultToken.split('.');
+			expect(parts.length).toBe(3);
+
+			// Decode payload and check claims
+			const payload = JSON.parse(atob(parts[1]));
+			expect(payload.aud).toBe('vault-test-id'); // Vault-specific audience
+			expect(payload.email).toBe('user@example.com');
+			expect(payload.iss).toBe('https://polyphony.uk');
+		});
+
+		it('should proceed to OAuth when SSO cookie is expired', async () => {
+			// Create an expired token by manipulating time
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2025-01-01'));
+			const expiredToken = await createValidSSOToken(testPrivateKey);
+			vi.useRealTimers();
+
+			const url = new URL(
+				'http://localhost/auth?vault_id=vault-test-id&callback=https://vault.example.com/callback'
+			);
+
+			try {
+				await GET({
+					url,
+					platform: {
+						env: {
+							DB: createMockDb(true, 'https://vault.example.com/callback', true, testPrivateKey),
+							API_KEY: 'test',
+							GOOGLE_CLIENT_ID: 'test-client-id'
+						}
+					},
+					cookies: createMockCookies(expiredToken)
+				} as unknown as Parameters<typeof GET>[0]);
+
+				expect(true).toBe(false); // Should throw redirect
+			} catch (redirect: any) {
+				// Should redirect to Google OAuth (expired SSO)
+				expect(redirect.status).toBe(302);
+				expect(redirect.location).toContain('accounts.google.com');
+			}
+		});
+
+		it('should proceed to OAuth when SSO cookie is invalid', async () => {
+			const url = new URL(
+				'http://localhost/auth?vault_id=vault-test-id&callback=https://vault.example.com/callback'
+			);
+
+			try {
+				await GET({
+					url,
+					platform: {
+						env: {
+							DB: createMockDb(true, 'https://vault.example.com/callback', true, testPrivateKey),
+							API_KEY: 'test',
+							GOOGLE_CLIENT_ID: 'test-client-id'
+						}
+					},
+					cookies: createMockCookies('invalid.jwt.token')
+				} as unknown as Parameters<typeof GET>[0]);
+
+				expect(true).toBe(false); // Should throw redirect
+			} catch (redirect: any) {
+				// Should redirect to Google OAuth (invalid SSO)
+				expect(redirect.status).toBe(302);
+				expect(redirect.location).toContain('accounts.google.com');
+			}
+		});
+
+		it('should proceed to OAuth when no SSO cookie present', async () => {
+			const url = new URL(
+				'http://localhost/auth?vault_id=vault-test-id&callback=https://vault.example.com/callback'
+			);
+
+			try {
+				await GET({
+					url,
+					platform: {
+						env: {
+							DB: createMockDb(true, 'https://vault.example.com/callback'),
+							API_KEY: 'test',
+							GOOGLE_CLIENT_ID: 'test-client-id'
+						}
+					},
+					cookies: createMockCookies(undefined)
+				} as unknown as Parameters<typeof GET>[0]);
+
+				expect(true).toBe(false); // Should throw redirect
+			} catch (redirect: any) {
+				// Should redirect to Google OAuth
+				expect(redirect.status).toBe(302);
+				expect(redirect.location).toContain('accounts.google.com');
+			}
+		});
 	});
 });


### PR DESCRIPTION
## Summary
Check for a valid `polyphony_sso` cookie before redirecting to OAuth. If a valid SSO cookie exists, skip OAuth entirely and issue a vault-specific JWT directly.

## Changes
- Add SSO cookie check at the start of `/auth` endpoint
- Validate SSO token has `polyphony-sso` audience
- If valid: issue vault JWT and redirect to callback (skip OAuth)
- If invalid/expired: silently proceed to OAuth (no error shown)
- Add `jwkToPem()` and `base64UrlDecode()` helpers for token verification

## User Experience
- **First login**: Normal OAuth flow (unchanged)
- **Subsequent vault visits** (within 30 days): Instant redirect with no OAuth prompt
- **Expired cookie**: Falls back to OAuth seamlessly

## Testing
- ✅ All 110 registry tests pass
- ✅ 5 new SSO-specific tests added:
  - Skip OAuth with valid SSO cookie
  - Valid vault JWT in redirect
  - Proceed to OAuth with expired cookie
  - Proceed to OAuth with invalid cookie  
  - Proceed to OAuth without cookie

## Related Issues
Closes #209
Part of Epic #207 (SSO Cookie - Multi-Org Convenience)