### PR TITLE
feat(registry): add /auth/logout endpoint to clear SSO cookie

### DIFF
--- a/apps/registry/src/routes/auth/logout/+server.ts
+++ b/apps/registry/src/routes/auth/logout/+server.ts
@@ -1,0 +1,55 @@
+// Logout endpoint - clears SSO cookie
+// GET/POST /auth/logout?callback=xxx
+
+// SSO cookie constants (must match callback/+server.ts)
+const SSO_COOKIE_NAME = 'polyphony_sso';
+const SSO_COOKIE_DOMAIN = '.polyphony.uk';
+const DEFAULT_REDIRECT = 'https://polyphony.uk';
+
+interface LogoutRequestEvent {
+	url: URL;
+	cookies: {
+		delete: (name: string, opts: object) => void;
+	};
+}
+
+/**
+ * Validate callback URL for security (prevent open redirect)
+ * Only allows polyphony.uk and its subdomains
+ */
+function isValidCallback(callback: string): boolean {
+	try {
+		const url = new URL(callback);
+		// Must be https and on polyphony.uk domain
+		return (
+			url.protocol === 'https:' &&
+			(url.hostname === 'polyphony.uk' || url.hostname.endsWith('.polyphony.uk'))
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Handle logout - clear SSO cookie and redirect
+ */
+function handleLogout({ url, cookies }: LogoutRequestEvent): Response {
+	// Clear SSO cookie
+	cookies.delete(SSO_COOKIE_NAME, {
+		domain: SSO_COOKIE_DOMAIN,
+		path: '/'
+	});
+
+	// Get callback URL (validated for security)
+	const callback = url.searchParams.get('callback');
+	const redirectUrl = callback && isValidCallback(callback) ? callback : DEFAULT_REDIRECT;
+
+	return new Response(null, {
+		status: 302,
+		headers: { Location: redirectUrl }
+	});
+}
+
+// Support both GET (logout links) and POST (form submissions)
+export const GET = handleLogout;
+export const POST = handleLogout;

--- a/apps/registry/src/tests/routes/auth/logout.spec.ts
+++ b/apps/registry/src/tests/routes/auth/logout.spec.ts
@@ -1,0 +1,110 @@
+// Test logout endpoint
+/// <reference types="@cloudflare/workers-types" />
+import { describe, it, expect, vi } from 'vitest';
+import { GET, POST } from '../../../routes/auth/logout/+server.js';
+
+// SSO cookie constants (must match implementation)
+const SSO_COOKIE_NAME = 'polyphony_sso';
+const SSO_COOKIE_DOMAIN = '.polyphony.uk';
+
+// Mock cookies helper
+const createMockCookies = () => {
+	const deleted: Array<{ name: string; opts: object }> = [];
+	return {
+		delete: (name: string, opts: object) => {
+			deleted.push({ name, opts });
+		},
+		getDeleted: () => deleted
+	};
+};
+
+describe('GET /auth/logout', () => {
+	it('should clear polyphony_sso cookie', async () => {
+		const mockCookies = createMockCookies();
+		const url = new URL('http://localhost/auth/logout');
+
+		const response = await GET({
+			url,
+			cookies: mockCookies
+		} as unknown as Parameters<typeof GET>[0]);
+
+		// Verify cookie was deleted
+		const deleted = mockCookies.getDeleted();
+		expect(deleted.length).toBe(1);
+		expect(deleted[0].name).toBe(SSO_COOKIE_NAME);
+		expect(deleted[0].opts).toMatchObject({
+			domain: SSO_COOKIE_DOMAIN,
+			path: '/'
+		});
+	});
+
+	it('should redirect to default URL when no callback provided', async () => {
+		const mockCookies = createMockCookies();
+		const url = new URL('http://localhost/auth/logout');
+
+		const response = await GET({
+			url,
+			cookies: mockCookies
+		} as unknown as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(302);
+		expect(response.headers.get('Location')).toBe('https://polyphony.uk');
+	});
+
+	it('should redirect to callback URL when provided', async () => {
+		const mockCookies = createMockCookies();
+		const url = new URL('http://localhost/auth/logout?callback=https://mychoir.polyphony.uk');
+
+		const response = await GET({
+			url,
+			cookies: mockCookies
+		} as unknown as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(302);
+		expect(response.headers.get('Location')).toBe('https://mychoir.polyphony.uk');
+	});
+
+	it('should only allow polyphony.uk subdomains as callback (security)', async () => {
+		const mockCookies = createMockCookies();
+		const url = new URL('http://localhost/auth/logout?callback=https://evil.com');
+
+		const response = await GET({
+			url,
+			cookies: mockCookies
+		} as unknown as Parameters<typeof GET>[0]);
+
+		// Should redirect to default, not evil.com
+		expect(response.status).toBe(302);
+		expect(response.headers.get('Location')).toBe('https://polyphony.uk');
+	});
+});
+
+describe('POST /auth/logout', () => {
+	it('should clear polyphony_sso cookie', async () => {
+		const mockCookies = createMockCookies();
+		const url = new URL('http://localhost/auth/logout');
+
+		const response = await POST({
+			url,
+			cookies: mockCookies
+		} as unknown as Parameters<typeof POST>[0]);
+
+		// Verify cookie was deleted
+		const deleted = mockCookies.getDeleted();
+		expect(deleted.length).toBe(1);
+		expect(deleted[0].name).toBe(SSO_COOKIE_NAME);
+	});
+
+	it('should redirect to callback URL', async () => {
+		const mockCookies = createMockCookies();
+		const url = new URL('http://localhost/auth/logout?callback=https://choir.polyphony.uk/members');
+
+		const response = await POST({
+			url,
+			cookies: mockCookies
+		} as unknown as Parameters<typeof POST>[0]);
+
+		expect(response.status).toBe(302);
+		expect(response.headers.get('Location')).toBe('https://choir.polyphony.uk/members');
+	});
+});


### PR DESCRIPTION
## Summary
Adds a logout endpoint to clear the SSO cookie set in #208 / #209.

## Changes
- **POST/GET `/auth/logout`** - Clears `polyphony_sso` cookie
- **Optional `?callback=`** - Redirect URL after logout
- **Security** - Validates callback is `polyphony.uk` or subdomain (prevents open redirect)
- **Fallback** - Redirects to `https://polyphony.uk` if no/invalid callback

## Testing
- 6 new tests for logout endpoint
- All 116 Registry tests pass
- All 1,097 monorepo tests pass

## Part of Epic #207
This is the final issue in the SSO Cookie epic:
- [x] #208 - Set SSO cookie in callback ✅ PR #211
- [x] #209 - Check SSO cookie in auth initiation ✅ PR #212
- [x] **#210 - Add /auth/logout endpoint** ← This PR

Closes #210