### PR TITLE
refactor: tech debt cleanup (#213, #206)

### DIFF
--- a/apps/registry/src/lib/crypto/jwk.ts
+++ b/apps/registry/src/lib/crypto/jwk.ts
@@ -1,0 +1,41 @@
+/**
+ * JWK to PEM conversion utilities
+ * Used for Ed25519 public key verification
+ */
+
+/**
+ * Convert JWK to PEM format for jose verification
+ * Specifically handles Ed25519 (EdDSA) public keys in JWK format
+ */
+export function jwkToPem(jwk: { x: string }): string {
+	// Ed25519 public key is 32 bytes, x coordinate is base64url encoded
+	const xBytes = base64UrlDecode(jwk.x);
+
+	// SPKI format for Ed25519:
+	// OID 1.3.101.112 = Ed25519
+	const oid = new Uint8Array([0x06, 0x03, 0x2b, 0x65, 0x70]);
+	const algoId = new Uint8Array([0x30, 0x05, ...oid]);
+	const pubKeyBits = new Uint8Array([0x03, 0x21, 0x00, ...xBytes]);
+	const spki = new Uint8Array([0x30, 0x2a, ...algoId, ...pubKeyBits]);
+
+	// Convert to PEM format
+	const base64 = btoa(String.fromCharCode(...spki));
+	return (
+		'-----BEGIN PUBLIC KEY-----\n' +
+		base64.match(/.{1,64}/g)!.join('\n') +
+		'\n-----END PUBLIC KEY-----'
+	);
+}
+
+/**
+ * Decode base64url to Uint8Array
+ * Handles URL-safe base64 encoding (- and _ characters)
+ */
+export function base64UrlDecode(str: string): Uint8Array {
+	// Convert base64url to standard base64
+	const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+	// Add padding if needed
+	const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+	const binary = atob(padded);
+	return new Uint8Array([...binary].map((c) => c.charCodeAt(0)));
+}

--- a/apps/vault/src/lib/server/utils/api-responses.ts
+++ b/apps/vault/src/lib/server/utils/api-responses.ts
@@ -28,3 +28,9 @@ export const notFoundError = (resource: string) =>
  */
 export const unauthorizedError = (message = 'Unauthorized') =>
 	error(401, message);
+
+/**
+ * Return a forbidden error (403) response
+ */
+export const forbiddenError = (message = 'Forbidden') =>
+	error(403, message);

--- a/apps/vault/src/lib/server/utils/id.ts
+++ b/apps/vault/src/lib/server/utils/id.ts
@@ -6,9 +6,13 @@
 /**
  * Generate a unique ID for database records
  * @param prefix Optional prefix for namespaced IDs (e.g., 'org_', 'invite_')
- * @returns A 21-character alphanumeric ID, optionally prefixed
+ * @returns A 21-character alphanumeric ID (or prefix + remaining chars to total 21)
  */
 export function generateId(prefix?: string): string {
-	const id = crypto.randomUUID().replace(/-/g, '').slice(0, 21);
-	return prefix ? `${prefix}${id.slice(0, 16)}` : id;
+	const base = crypto.randomUUID().replace(/-/g, '');
+	if (!prefix) {
+		return base.slice(0, 21);
+	}
+	// With prefix: total length is 21 chars (prefix + remaining)
+	return `${prefix}${base.slice(0, 21 - prefix.length)}`;
 }

--- a/apps/vault/src/lib/server/utils/strings.ts
+++ b/apps/vault/src/lib/server/utils/strings.ts
@@ -7,7 +7,8 @@
  * Used for partial updates where empty = unset
  */
 export function trimOrNull(value: unknown): string | null {
-	if (value === null) return null;
+	// Explicitly handle null and undefined
+	if (value == null) return null;
 	return typeof value === 'string' ? value.trim() || null : null;
 }
 


### PR DESCRIPTION
## Summary
Addresses two tech debt issues in a single PR.

## #213 - Extract jwkToPem to shared module

- **New**: `apps/registry/src/lib/crypto/jwk.ts`
  - `jwkToPem()` - Convert Ed25519 JWK to PEM format
  - `base64UrlDecode()` - URL-safe base64 decoding
- Updated `/auth/+server.ts` to import from shared module
- Removes inline implementation (~30 lines)

## #206 - Review feedback

Addresses the polish items from the previous tech debt PR:

### 1. `generateId()` - Consistent length
```typescript
// Before: no prefix = 21, with prefix = prefix.length + 16 (inconsistent)
// After: always 21 total chars
return \`\${prefix}\${base.slice(0, 21 - prefix.length)}\`;
```

### 2. `trimOrNull()` - Explicit null/undefined handling
```typescript
// Before: if (value === null)
// After: if (value == null)  // handles both null and undefined
```

### 3. Add `forbiddenError(403)` helper
```typescript
export const forbiddenError = (message = 'Forbidden') =>
  error(403, message);
```

## Testing
- ✅ All 1,097 tests pass
- ✅ 0 TypeScript errors

Closes #213