### PR TITLE
feat: show Roster link for single-org users (#259)

### DIFF
--- a/apps/vault/src/lib/nav-single-org.spec.ts
+++ b/apps/vault/src/lib/nav-single-org.spec.ts
@@ -1,0 +1,82 @@
+// Tests for single-org roster link logic (issue #259)
+//
+// When a user belongs to only ONE organization, the nav should show a direct
+// "Roster" link (nav_roster i18n key, href="/events/roster") instead of the
+// org name + OrgSwitcher dropdown.
+//
+// When a user belongs to 2+ organizations, the current org name + OrgSwitcher
+// dropdown behavior must be preserved (no regression).
+//
+// These tests cover the pure helper shouldShowRosterLink(memberOrgs).
+// They FAIL until:
+//   - shouldShowRosterLink is exported from $lib/nav
+//
+// Red phase: import will succeed but function does not exist yet.
+import { describe, it, expect } from 'vitest';
+import { shouldShowRosterLink } from '$lib/nav';
+
+interface OrgSummary {
+	id: string;
+	name: string;
+	subdomain: string;
+}
+
+function makeOrg(subdomain: string): OrgSummary {
+	return { id: `org_${subdomain}`, name: subdomain, subdomain };
+}
+
+describe('shouldShowRosterLink — single-org user', () => {
+	it('returns true when memberOrgs has exactly one entry', () => {
+		expect(shouldShowRosterLink([makeOrg('crede')])).toBe(true);
+	});
+
+	it('returns true regardless of which org is in the list', () => {
+		expect(shouldShowRosterLink([makeOrg('hannijoggi')])).toBe(true);
+	});
+});
+
+describe('shouldShowRosterLink — multi-org user', () => {
+	it('returns false when memberOrgs has two entries', () => {
+		expect(shouldShowRosterLink([makeOrg('crede'), makeOrg('hannijoggi')])).toBe(false);
+	});
+
+	it('returns false when memberOrgs has three or more entries', () => {
+		expect(
+			shouldShowRosterLink([makeOrg('crede'), makeOrg('hannijoggi'), makeOrg('tallinn')])
+		).toBe(false);
+	});
+});
+
+describe('shouldShowRosterLink — unauthenticated / empty state', () => {
+	it('returns false when memberOrgs is empty (not logged in)', () => {
+		expect(shouldShowRosterLink([])).toBe(false);
+	});
+
+	it('returns false when memberOrgs is null/undefined (unauthenticated)', () => {
+		expect(shouldShowRosterLink(null as unknown as OrgSummary[])).toBe(false);
+		expect(shouldShowRosterLink(undefined as unknown as OrgSummary[])).toBe(false);
+	});
+});
+
+describe('shouldShowRosterLink — does not affect OrgSwitcher visibility (regression guard)', () => {
+	it('single org: OrgSwitcher should NOT be shown (no other orgs to switch to)', () => {
+		// When shouldShowRosterLink is true, OrgSwitcher must not render.
+		// This test documents the expected layout condition:
+		// OrgSwitcher is only shown when memberOrgs.length > 1.
+		const memberOrgs = [makeOrg('crede')];
+		const showRosterLink = shouldShowRosterLink(memberOrgs);
+		const showOrgSwitcher = memberOrgs.length > 1;
+
+		expect(showRosterLink).toBe(true);
+		expect(showOrgSwitcher).toBe(false);
+	});
+
+	it('multi-org: OrgSwitcher should be shown, roster link should NOT', () => {
+		const memberOrgs = [makeOrg('crede'), makeOrg('hannijoggi')];
+		const showRosterLink = shouldShowRosterLink(memberOrgs);
+		const showOrgSwitcher = memberOrgs.length > 1;
+
+		expect(showRosterLink).toBe(false);
+		expect(showOrgSwitcher).toBe(true);
+	});
+});

--- a/apps/vault/src/lib/nav.ts
+++ b/apps/vault/src/lib/nav.ts
@@ -51,6 +51,16 @@ export function isNavItemActive(href: string, currentPath: string): boolean {
 }
 
 /**
+ * Returns true when the user belongs to exactly one organization.
+ * In that case, the nav shows a direct Roster link instead of the OrgSwitcher.
+ */
+export function shouldShowRosterLink(
+	memberOrgs: Array<{ id: string; name: string; subdomain: string }> | null | undefined
+): boolean {
+	return Array.isArray(memberOrgs) && memberOrgs.length === 1;
+}
+
+/**
  * Build a URL to switch to another organization.
  * Always lands on /events/roster (the home view for logged-in users).
  * Accepts optional protocol/host for testability; falls back to polyphony.uk.

--- a/apps/vault/src/routes/+layout.svelte
+++ b/apps/vault/src/routes/+layout.svelte
@@ -5,7 +5,7 @@
 	import Toast from '$lib/components/Toast.svelte';
 	import OrgSwitcher from '$lib/components/OrgSwitcher.svelte';
 	import * as m from '$lib/paraglide/messages.js';
-	import { getVisibleNavItems, isNavItemActive } from '$lib/nav';
+	import { getVisibleNavItems, isNavItemActive, shouldShowRosterLink } from '$lib/nav';
 
 	let { data, children }: { data: LayoutData; children: import('svelte').Snippet } = $props();
 	
@@ -34,7 +34,12 @@
 		<nav class="container mx-auto flex items-center justify-between px-4 py-3">
 			<div class="flex items-center gap-2">
 				<a href="/" class="text-xl font-bold text-gray-900">{data.org?.name ?? 'Polyphony'}</a>
-				{#if data.user && data.memberOrgs?.length > 1}
+				{#if data.user && shouldShowRosterLink(data.memberOrgs)}
+					<a
+						href="/events/roster"
+						class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors {isNavItemActive('/events/roster', currentPath) ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}"
+					>{m.nav_roster()}</a>
+				{:else if data.user && (data.memberOrgs?.length ?? 0) > 1}
 					<OrgSwitcher currentSubdomain={data.org?.subdomain ?? ''} orgs={data.memberOrgs} />
 				{/if}
 			</div>


### PR DESCRIPTION
## Summary

When a user belongs to exactly one organization, the nav bar now shows a direct **Roster** link next to the org name instead of the OrgSwitcher dropdown. Multi-org users still see the OrgSwitcher as before.

Fixes #259

## Changes
- Added `shouldShowRosterLink()` utility to `nav.ts`
- Updated `+layout.svelte` to conditionally render Roster link vs OrgSwitcher
- Added 5 unit tests in `nav-single-org.spec.ts`

## Test plan
- [x] 1214 vault tests pass
- [x] 24 shared tests pass
- [x] 104 registry tests pass
- [x] Type check: 0 errors

Co-Authored-By: