### PR TITLE
feat(vault): org-scope voices table (#252)

### DIFF
--- a/apps/vault/migrations/0043_voices_org_id.sql
+++ b/apps/vault/migrations/0043_voices_org_id.sql
@@ -1,0 +1,141 @@
+-- Migration 0043: Add org_id to voices (Schema V2)
+-- Issue #252: Org-scope the voices table
+--
+-- Voices become per-organization: each org gets its own copy.
+-- Uses D1-safe rebuild pattern (CASCADE fires on DROP TABLE regardless
+-- of PRAGMA foreign_keys).
+--
+-- Child tables affected by CASCADE on DROP TABLE voices:
+--   member_voices  (voices FK)
+--   invite_voices  (voices FK)
+
+-- ============================================================================
+-- STEP 1: Save child data that will be lost to CASCADE
+-- ============================================================================
+
+CREATE TABLE _tmp_member_voices AS SELECT * FROM member_voices;
+CREATE TABLE _tmp_invite_voices AS SELECT * FROM invite_voices;
+
+-- ============================================================================
+-- STEP 2: Create voices_new with org_id NOT NULL
+-- ============================================================================
+
+CREATE TABLE voices_new (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    abbreviation TEXT NOT NULL,
+    category TEXT NOT NULL CHECK (category IN ('vocal', 'instrumental')),
+    range_group TEXT,
+    display_order INTEGER NOT NULL,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    UNIQUE(org_id, name)
+);
+
+-- ============================================================================
+-- STEP 3: Seed voices for EVERY organization
+-- Each org gets a copy of every existing voice row with an org-prefixed ID.
+-- ============================================================================
+
+INSERT INTO voices_new (id, org_id, name, abbreviation, category, range_group, display_order, is_active)
+SELECT o.id || '_' || v.id, o.id, v.name, v.abbreviation, v.category, v.range_group, v.display_order, v.is_active
+FROM voices v
+CROSS JOIN organizations o;
+
+-- ============================================================================
+-- STEP 4: Drop old voices table (CASCADE deletes member_voices, invite_voices)
+-- ============================================================================
+
+DROP TABLE voices;
+
+-- ============================================================================
+-- STEP 5: Rename new table
+-- ============================================================================
+
+ALTER TABLE voices_new RENAME TO voices;
+
+-- ============================================================================
+-- STEP 6: Restore member_voices with org-scoped voice IDs
+-- Map each member_voice to the correct org via member_organizations.
+-- NOTE: If a member belongs to multiple orgs, this JOIN produces one row per
+-- org, duplicating the voice assignment into each org. This is acceptable for
+-- the current single-org deployment. For multi-org scenarios, consider
+-- restricting to the member's primary org or requiring manual assignment.
+-- ============================================================================
+
+INSERT INTO member_voices (member_id, voice_id, is_primary, assigned_at, assigned_by, notes)
+SELECT
+    t.member_id,
+    mo.org_id || '_' || t.voice_id,
+    t.is_primary,
+    t.assigned_at,
+    t.assigned_by,
+    t.notes
+FROM _tmp_member_voices t
+JOIN member_organizations mo ON mo.member_id = t.member_id;
+
+-- ============================================================================
+-- STEP 7: Restore invite_voices with org-scoped voice IDs
+-- Map each invite_voice to the correct org via invites.org_id.
+-- ============================================================================
+
+INSERT INTO invite_voices (invite_id, voice_id, is_primary)
+SELECT
+    t.invite_id,
+    i.org_id || '_' || t.voice_id,
+    t.is_primary
+FROM _tmp_invite_voices t
+JOIN invites i ON i.id = t.invite_id;
+
+-- ============================================================================
+-- STEP 8: Drop temp tables
+-- ============================================================================
+
+DROP TABLE _tmp_member_voices;
+DROP TABLE _tmp_invite_voices;
+
+-- ============================================================================
+-- STEP 9: Recreate voices indexes (child table indexes survive CASCADE)
+-- ============================================================================
+
+CREATE INDEX idx_voices_org ON voices(org_id);
+CREATE INDEX idx_voices_category ON voices(category);
+CREATE INDEX idx_voices_display_order ON voices(display_order);
+
+-- ============================================================================
+-- STEP 10: Recreate voice triggers (org-scoped)
+-- When setting a voice as primary, only clear other primaries in same org.
+-- ============================================================================
+
+DROP TRIGGER IF EXISTS enforce_single_primary_voice;
+DROP TRIGGER IF EXISTS enforce_single_primary_voice_update;
+
+CREATE TRIGGER enforce_single_primary_voice
+BEFORE INSERT ON member_voices
+WHEN NEW.is_primary = 1
+BEGIN
+    UPDATE member_voices
+    SET is_primary = 0
+    WHERE member_id = NEW.member_id
+      AND voice_id IN (
+          SELECT v1.id
+          FROM voices v1
+          JOIN voices v2 ON v1.org_id = v2.org_id
+          WHERE v2.id = NEW.voice_id
+      );
+END;
+
+CREATE TRIGGER enforce_single_primary_voice_update
+BEFORE UPDATE OF is_primary ON member_voices
+WHEN NEW.is_primary = 1
+BEGIN
+    UPDATE member_voices
+    SET is_primary = 0
+    WHERE member_id = NEW.member_id
+      AND voice_id IN (
+          SELECT v1.id
+          FROM voices v1
+          JOIN voices v2 ON v1.org_id = v2.org_id
+          WHERE v2.id = NEW.voice_id
+      );
+END;

--- a/apps/vault/src/lib/server/db/voices.spec.ts
+++ b/apps/vault/src/lib/server/db/voices.spec.ts
@@ -9,13 +9,16 @@ import {
 } from './voices';
 import type { CreateVoiceInput, Voice } from '$lib/types';
 
-// Mock D1Database for testing
+const TEST_ORG_ID = 'org_test_001';
+
+// Mock D1Database for testing (org-scoped)
 function createMockDB(): D1Database {
 	const voices = new Map<string, any>();
 
-	// Seed default voices (matching migration)
+	// Seed default voices (matching migration, scoped to TEST_ORG_ID)
 	voices.set('soprano', {
 		id: 'soprano',
+		org_id: TEST_ORG_ID,
 		name: 'Soprano',
 		abbreviation: 'S',
 		category: 'vocal',
@@ -25,6 +28,7 @@ function createMockDB(): D1Database {
 	});
 	voices.set('alto', {
 		id: 'alto',
+		org_id: TEST_ORG_ID,
 		name: 'Alto',
 		abbreviation: 'A',
 		category: 'vocal',
@@ -34,6 +38,7 @@ function createMockDB(): D1Database {
 	});
 	voices.set('tenor', {
 		id: 'tenor',
+		org_id: TEST_ORG_ID,
 		name: 'Tenor',
 		abbreviation: 'T',
 		category: 'vocal',
@@ -43,6 +48,7 @@ function createMockDB(): D1Database {
 	});
 	voices.set('soprano-1', {
 		id: 'soprano-1',
+		org_id: TEST_ORG_ID,
 		name: 'Soprano I',
 		abbreviation: 'S1',
 		category: 'vocal',
@@ -56,23 +62,32 @@ function createMockDB(): D1Database {
 			return {
 				bind: (...params: any[]) => ({
 					first: async () => {
+						if (sql.includes('WHERE id = ? AND org_id = ?')) {
+							const voice = voices.get(params[0]);
+							if (voice && voice.org_id === params[1]) return voice;
+							return null;
+						}
 						if (sql.includes('WHERE id = ?')) {
 							return voices.get(params[0]) || null;
 						}
 						return null;
 					},
 					all: async () => {
-						const results = Array.from(voices.values());
-						if (sql.includes('WHERE is_active = 1')) {
-							return { results: results.filter((v) => v.is_active === 1) };
+						const allVoices = Array.from(voices.values());
+						// Filter by org_id (first bind param)
+						const orgId = params[0];
+						let filtered = allVoices.filter(v => v.org_id === orgId);
+						if (sql.includes('AND is_active = 1')) {
+							filtered = filtered.filter((v) => v.is_active === 1);
 						}
-						return { results };
+						return { results: filtered };
 					},
 					run: async () => {
 						if (sql.includes('INSERT INTO voices')) {
-							const [id, name, abbr, category, rangeGroup, displayOrder, isActive] = params;
+							const [id, orgId, name, abbr, category, rangeGroup, displayOrder, isActive] = params;
 							voices.set(id, {
 								id,
+								org_id: orgId,
 								name,
 								abbreviation: abbr,
 								category,
@@ -83,9 +98,9 @@ function createMockDB(): D1Database {
 							return { success: true, meta: { changes: 1 } };
 						}
 						if (sql.includes('UPDATE voices SET is_active')) {
-							const [isActive, id] = params;
+							const [isActive, id, orgId] = params;
 							const voice = voices.get(id);
-							if (voice) {
+							if (voice && voice.org_id === orgId) {
 								voice.is_active = isActive;
 								return { success: true, meta: { changes: 1 } };
 							}
@@ -122,13 +137,13 @@ describe('voices.ts', () => {
 
 	describe('getActiveVoices', () => {
 		it('should return only active voices', async () => {
-			const voices = await getActiveVoices(db);
+			const voices = await getActiveVoices(db, TEST_ORG_ID);
 			expect(voices.length).toBe(3); // soprano, alto, tenor
 			expect(voices.every((v: Voice) => v.isActive)).toBe(true);
 		});
 
 		it('should return voices ordered by display_order', async () => {
-			const voices = await getActiveVoices(db);
+			const voices = await getActiveVoices(db, TEST_ORG_ID);
 			expect(voices[0].name).toBe('Soprano');
 			expect(voices[1].name).toBe('Alto');
 			expect(voices[2].name).toBe('Tenor');
@@ -137,12 +152,12 @@ describe('voices.ts', () => {
 
 	describe('getAllVoices', () => {
 		it('should return all voices including inactive', async () => {
-			const voices = await getAllVoices(db);
+			const voices = await getAllVoices(db, TEST_ORG_ID);
 			expect(voices.length).toBeGreaterThanOrEqual(4); // soprano, alto, tenor, soprano-1
 		});
 
 		it('should include inactive voices', async () => {
-			const voices = await getAllVoices(db);
+			const voices = await getAllVoices(db, TEST_ORG_ID);
 			const soprano1 = voices.find((v: Voice) => v.id === 'soprano-1');
 			expect(soprano1).toBeDefined();
 			expect(soprano1!.isActive).toBe(false);
@@ -151,19 +166,19 @@ describe('voices.ts', () => {
 
 	describe('getVoiceById', () => {
 		it('should return voice by id', async () => {
-			const voice = await getVoiceById(db, 'soprano');
+			const voice = await getVoiceById(db, 'soprano', TEST_ORG_ID);
 			expect(voice).toBeDefined();
 			expect(voice!.name).toBe('Soprano');
 			expect(voice!.abbreviation).toBe('S');
 		});
 
 		it('should return null for non-existent id', async () => {
-			const voice = await getVoiceById(db, 'nonexistent');
+			const voice = await getVoiceById(db, 'nonexistent', TEST_ORG_ID);
 			expect(voice).toBeNull();
 		});
 
 		it('should convert snake_case to camelCase', async () => {
-			const voice = await getVoiceById(db, 'soprano');
+			const voice = await getVoiceById(db, 'soprano', TEST_ORG_ID);
 			expect(voice).toHaveProperty('rangeGroup');
 			expect(voice).toHaveProperty('displayOrder');
 			expect(voice).toHaveProperty('isActive');
@@ -173,6 +188,7 @@ describe('voices.ts', () => {
 	describe('createVoice', () => {
 		it('should create a new voice', async () => {
 			const input: CreateVoiceInput = {
+				orgId: TEST_ORG_ID,
 				name: 'Mezzo-Soprano',
 				abbreviation: 'MS',
 				category: 'vocal',
@@ -186,8 +202,9 @@ describe('voices.ts', () => {
 			expect(voice.isActive).toBe(true);
 		});
 
-		it('should generate id from name', async () => {
+		it('should generate id from org + name', async () => {
 			const input: CreateVoiceInput = {
+				orgId: TEST_ORG_ID,
 				name: 'Mezzo-Soprano',
 				abbreviation: 'MS',
 				category: 'vocal',
@@ -195,11 +212,12 @@ describe('voices.ts', () => {
 			};
 
 			const voice = await createVoice(db, input);
-			expect(voice.id).toBe('mezzo-soprano');
+			expect(voice.id).toBe(`${TEST_ORG_ID}_mezzo-soprano`);
 		});
 
 		it('should allow creating inactive voices', async () => {
 			const input: CreateVoiceInput = {
+				orgId: TEST_ORG_ID,
 				name: 'Counter-Tenor',
 				abbreviation: 'CT',
 				category: 'vocal',
@@ -214,23 +232,23 @@ describe('voices.ts', () => {
 
 	describe('toggleVoiceActive', () => {
 		it('should activate an inactive voice', async () => {
-			const result = await toggleVoiceActive(db, 'soprano-1', true);
+			const result = await toggleVoiceActive(db, 'soprano-1', true, TEST_ORG_ID);
 			expect(result).toBe(true);
 
-			const voice = await getVoiceById(db, 'soprano-1');
+			const voice = await getVoiceById(db, 'soprano-1', TEST_ORG_ID);
 			expect(voice!.isActive).toBe(true);
 		});
 
 		it('should deactivate an active voice', async () => {
-			const result = await toggleVoiceActive(db, 'soprano', false);
+			const result = await toggleVoiceActive(db, 'soprano', false, TEST_ORG_ID);
 			expect(result).toBe(true);
 
-			const voice = await getVoiceById(db, 'soprano');
+			const voice = await getVoiceById(db, 'soprano', TEST_ORG_ID);
 			expect(voice!.isActive).toBe(false);
 		});
 
 		it('should return false for non-existent voice', async () => {
-			const result = await toggleVoiceActive(db, 'nonexistent', true);
+			const result = await toggleVoiceActive(db, 'nonexistent', true, TEST_ORG_ID);
 			expect(result).toBe(false);
 		});
 	});

--- a/apps/vault/src/lib/types.ts
+++ b/apps/vault/src/lib/types.ts
@@ -253,6 +253,7 @@ export interface InviteSection {
  * Input for creating a new voice
  */
 export interface CreateVoiceInput {
+	orgId: string; // Schema V2: required
 	name: string;
 	abbreviation: string;
 	category: 'vocal' | 'instrumental';

--- a/apps/vault/src/routes/api/voices/+server.ts
+++ b/apps/vault/src/routes/api/voices/+server.ts
@@ -35,6 +35,7 @@ export async function POST({ request, platform, cookies, locals }: RequestEvent)
 
 	// Build input with defaults
 	const input: CreateVoiceInput = {
+		orgId: locals.org.id,
 		name: body.name.trim(),
 		abbreviation: body.abbreviation.trim(),
 		category: body.category,

--- a/apps/vault/src/routes/api/voices/[id]/+server.ts
+++ b/apps/vault/src/routes/api/voices/[id]/+server.ts
@@ -27,15 +27,15 @@ export async function PATCH({ params, request, platform, cookies, locals }: Requ
 		return json({ error: 'isActive must be a boolean' }, { status: 400 });
 	}
 
-	// Toggle the voice
-	const updated = await toggleVoiceActive(db, voiceId, body.isActive);
+	// Toggle the voice (org-scoped)
+	const updated = await toggleVoiceActive(db, voiceId, body.isActive, locals.org.id);
 
 	if (!updated) {
 		throw error(404, 'Voice not found');
 	}
 
 	// Return updated voice
-	const voice = await getVoiceById(db, voiceId);
+	const voice = await getVoiceById(db, voiceId, locals.org.id);
 	return json(voice);
 }
 
@@ -55,7 +55,7 @@ export async function DELETE({ params, platform, cookies, locals }: RequestEvent
 	}
 
 	try {
-		const deleted = await deleteVoice(db, voiceId);
+		const deleted = await deleteVoice(db, voiceId, locals.org.id);
 		if (!deleted) {
 			throw error(404, 'Voice not found');
 		}

--- a/apps/vault/src/routes/api/voices/[id]/reassign/+server.ts
+++ b/apps/vault/src/routes/api/voices/[id]/reassign/+server.ts
@@ -27,13 +27,13 @@ export async function POST({ params, request, platform, cookies, locals }: Reque
 	}
 
 	// Validate source voice exists
-	const sourceVoice = await getVoiceById(db, sourceVoiceId);
+	const sourceVoice = await getVoiceById(db, sourceVoiceId, locals.org.id);
 	if (!sourceVoice) {
 		throw error(404, 'Source voice not found');
 	}
 
 	// Validate target voice exists
-	const targetVoice = await getVoiceById(db, body.targetVoiceId);
+	const targetVoice = await getVoiceById(db, body.targetVoiceId, locals.org.id);
 	if (!targetVoice) {
 		return json({ error: 'Target voice not found' }, { status: 400 });
 	}
@@ -44,7 +44,7 @@ export async function POST({ params, request, platform, cookies, locals }: Reque
 	}
 
 	// Perform reassignment
-	const movedCount = await reassignVoice(db, sourceVoiceId, body.targetVoiceId);
+	const movedCount = await reassignVoice(db, sourceVoiceId, body.targetVoiceId, locals.org.id);
 
 	return json({
 		success: true,

--- a/apps/vault/src/routes/api/voices/reorder/+server.ts
+++ b/apps/vault/src/routes/api/voices/reorder/+server.ts
@@ -26,9 +26,9 @@ export async function POST({ request, platform, cookies, locals }: RequestEvent)
 		return json({ error: 'voiceIds must contain only strings' }, { status: 400 });
 	}
 
-	await reorderVoices(db, body.voiceIds);
+	await reorderVoices(db, body.voiceIds, locals.org.id);
 
 	// Return updated voices list
-	const voices = await getAllVoicesWithCounts(db);
+	const voices = await getAllVoicesWithCounts(db, locals.org.id);
 	return json(voices);
 }

--- a/apps/vault/src/routes/invite/+page.server.ts
+++ b/apps/vault/src/routes/invite/+page.server.ts
@@ -21,7 +21,7 @@ export const load: PageServerLoad = async ({ platform, cookies, url, locals }) =
 
 	// Load active voices and sections for the form
 	const [voices, sections] = await Promise.all([
-		getActiveVoices(db),
+		getActiveVoices(db, orgId),
 		getActiveSections(db, orgId)
 	]);
 

--- a/apps/vault/src/routes/members/+page.server.ts
+++ b/apps/vault/src/routes/members/+page.server.ts
@@ -52,7 +52,7 @@ async function loadMemberPageData(db: D1Database, orgId: OrgId, url: URL) {
 	const invites = formatInvites(pendingInvites, baseUrl);
 
 	const [availableVoices, availableSections] = await Promise.all([
-		getActiveVoices(db),
+		getActiveVoices(db, orgId),
 		getActiveSections(db, orgId)
 	]);
 

--- a/apps/vault/src/routes/members/[id]/+page.server.ts
+++ b/apps/vault/src/routes/members/[id]/+page.server.ts
@@ -39,7 +39,7 @@ async function loadAuthContext(db: D1Database, cookies: unknown, orgId: OrgId): 
 async function loadAdminData(db: D1Database, isAdmin: boolean, orgId: OrgId) {
 	if (!isAdmin) return { availableVoices: [], availableSections: [] };
 	const [availableVoices, availableSections] = await Promise.all([
-		getActiveVoices(db),
+		getActiveVoices(db, orgId),
 		getActiveSections(db, orgId)
 	]);
 	return { availableVoices, availableSections };

--- a/apps/vault/src/routes/members/add-roster/+page.server.ts
+++ b/apps/vault/src/routes/members/add-roster/+page.server.ts
@@ -18,7 +18,7 @@ export const load: PageServerLoad = async ({ platform, cookies, locals }) => {
 	const orgId = locals.org.id;
 
 	// Load available voices and sections for multi-select
-	const availableVoices = await getActiveVoices(db);
+	const availableVoices = await getActiveVoices(db, orgId);
 	const availableSections = await getActiveSections(db, orgId);
 
 	return {

--- a/apps/vault/src/routes/settings/+page.server.ts
+++ b/apps/vault/src/routes/settings/+page.server.ts
@@ -19,7 +19,7 @@ export const load: PageServerLoad = async ({ platform, cookies, locals }) => {
 	// Load settings, voices (with counts), sections (with counts), and organization
 	const [settings, voices, sections, organization] = await Promise.all([
 		getAllSettings(db, orgId),
-		getAllVoicesWithCounts(db),
+		getAllVoicesWithCounts(db, orgId),
 		getAllSectionsWithCounts(db, orgId),
 		getOrganizationById(db, orgId)
 	]);

--- a/apps/vault/src/tests/lib/server/db/voices-org-scoped.spec.ts
+++ b/apps/vault/src/tests/lib/server/db/voices-org-scoped.spec.ts
@@ -1,0 +1,470 @@
+// Failing tests for issue #252: voices table lacks org_id — all 9 DB functions are unscoped
+//
+// Vulnerabilities:
+// 1. getActiveVoices(db) has no orgId param — returns ALL orgs' voices
+// 2. getAllVoicesWithCounts(db) has no orgId param — cross-org data leak
+// 3. createVoice(db, input) has no orgId — voices stored globally
+// 4. toggleVoiceActive(db, id, flag) has no orgId — admin on org A can toggle org B's voices
+// 5. deleteVoice(db, id) has no orgId — cross-org delete possible
+// 6. reorderVoices(db, ids) has no orgId — can reorder another org's voices
+// 7. Two orgs currently share the same voice pool (day-one multi-org blocker)
+//
+// All failing tests are in the RED phase — the org-scope contract doesn't exist yet.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+vi.mock('$lib/server/db/voices', () => ({
+	getActiveVoices: vi.fn(),
+	getAllVoices: vi.fn(),
+	getAllVoicesWithCounts: vi.fn(),
+	getVoiceById: vi.fn(),
+	createVoice: vi.fn(),
+	toggleVoiceActive: vi.fn(),
+	deleteVoice: vi.fn(),
+	reorderVoices: vi.fn(),
+	reassignVoice: vi.fn()
+}));
+
+vi.mock('$lib/server/auth/middleware', () => ({
+	getAuthenticatedMember: vi.fn(),
+	assertAdmin: vi.fn()
+}));
+
+import {
+	getActiveVoices,
+	getAllVoicesWithCounts,
+	createVoice,
+	toggleVoiceActive,
+	deleteVoice,
+	reorderVoices
+} from '$lib/server/db/voices';
+import { getAuthenticatedMember, assertAdmin } from '$lib/server/auth/middleware';
+import { POST } from '../../../../routes/api/voices/+server';
+import { PATCH, DELETE } from '../../../../routes/api/voices/[id]/+server';
+import { POST as REORDER } from '../../../../routes/api/voices/reorder/+server';
+import type { Member } from '$lib/server/db/members';
+import type { Voice } from '$lib/types';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const ORG_A_ID = 'org_crede_001';
+const ORG_B_ID = 'org_hannijoggi_001';
+
+const mockAdmin: Member = {
+	id: 'admin_001',
+	name: 'Admin User',
+	nickname: null,
+	email_id: 'admin@crede.example',
+	email_contact: null,
+	roles: ['admin'],
+	voices: [],
+	sections: [],
+	invited_by: null,
+	joined_at: '2026-01-01T00:00:00Z'
+};
+
+// Org A's voices
+const ORG_A_SOPRANO: Voice = {
+	id: 'voice_crede_soprano',
+	name: 'Soprano',
+	abbreviation: 'S',
+	category: 'vocal',
+	rangeGroup: 'soprano',
+	displayOrder: 10,
+	isActive: true
+};
+
+const ORG_A_ALTO: Voice = {
+	id: 'voice_crede_alto',
+	name: 'Alto',
+	abbreviation: 'A',
+	category: 'vocal',
+	rangeGroup: 'alto',
+	displayOrder: 20,
+	isActive: true
+};
+
+// Org B's voices — same names, different IDs
+const ORG_B_SOPRANO: Voice = {
+	id: 'voice_hov_soprano',
+	name: 'Soprano',
+	abbreviation: 'S',
+	category: 'vocal',
+	rangeGroup: 'soprano',
+	displayOrder: 10,
+	isActive: true
+};
+
+function makeEvent(opts: {
+	org?: { id: string } | null;
+	body?: unknown;
+	params?: Record<string, string>;
+	method?: string;
+} = {}) {
+	const { org = { id: ORG_A_ID }, body, params = {}, method = 'POST' } = opts;
+	return {
+		platform: { env: { DB: {} as D1Database } },
+		cookies: { get: vi.fn(), getAll: vi.fn(), set: vi.fn(), delete: vi.fn(), serialize: vi.fn() },
+		params,
+		request: new Request('https://crede.polyphony.uk/api/voices', {
+			method,
+			headers: body ? { 'Content-Type': 'application/json' } : {},
+			body: body ? JSON.stringify(body) : undefined
+		}),
+		url: new URL('https://crede.polyphony.uk/api/voices'),
+		locals: { org },
+		route: { id: '/api/voices' },
+		getClientAddress: () => '127.0.0.1',
+		fetch: vi.fn(),
+		setHeaders: vi.fn(),
+		isDataRequest: false,
+		isSubRequest: false
+	} as any;
+}
+
+// ============================================================================
+// Part 1: DB function signatures must accept orgId
+// ============================================================================
+
+describe('voices DB functions — must accept orgId parameter (#252)', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('getActiveVoices must accept orgId as second parameter', () => {
+		// After fix: getActiveVoices(db, orgId) filters by org_id
+		// This test documents the required signature.
+		// Currently the function signature is getActiveVoices(db) — no orgId.
+		const fn = getActiveVoices as unknown as (db: D1Database, orgId: string) => Promise<Voice[]>;
+		vi.mocked(getActiveVoices).mockResolvedValue([ORG_A_SOPRANO]);
+
+		// If the function only accepts 1 param, calling with 2 would succeed at runtime
+		// but the SQL wouldn't filter — we verify the mock records the orgId arg
+		fn({} as D1Database, ORG_A_ID);
+		expect(vi.mocked(getActiveVoices)).toHaveBeenCalledWith(expect.anything(), ORG_A_ID);
+	});
+
+	it('getAllVoicesWithCounts must accept orgId as second parameter', () => {
+		const fn = getAllVoicesWithCounts as unknown as (db: D1Database, orgId: string) => Promise<any[]>;
+		vi.mocked(getAllVoicesWithCounts).mockResolvedValue([]);
+
+		fn({} as D1Database, ORG_A_ID);
+		expect(vi.mocked(getAllVoicesWithCounts)).toHaveBeenCalledWith(expect.anything(), ORG_A_ID);
+	});
+
+	it('createVoice input must include orgId field', () => {
+		// After fix: CreateVoiceInput gains orgId
+		const validInput = {
+			name: 'Soprano',
+			abbreviation: 'S',
+			category: 'vocal' as const,
+			displayOrder: 10,
+			orgId: ORG_A_ID // must exist after fix
+		};
+		expect(validInput.orgId).toBeDefined();
+	});
+
+	it('toggleVoiceActive must accept orgId to prevent cross-org toggle', () => {
+		const fn = toggleVoiceActive as unknown as (db: D1Database, id: string, isActive: boolean, orgId: string) => Promise<boolean>;
+		vi.mocked(toggleVoiceActive).mockResolvedValue(true);
+
+		fn({} as D1Database, 'voice_crede_soprano', false, ORG_A_ID);
+		expect(vi.mocked(toggleVoiceActive)).toHaveBeenCalledWith(
+			expect.anything(),
+			'voice_crede_soprano',
+			false,
+			ORG_A_ID
+		);
+	});
+
+	it('deleteVoice must accept orgId to prevent cross-org delete', () => {
+		const fn = deleteVoice as unknown as (db: D1Database, id: string, orgId: string) => Promise<boolean>;
+		vi.mocked(deleteVoice).mockResolvedValue(true);
+
+		fn({} as D1Database, 'voice_crede_soprano', ORG_A_ID);
+		expect(vi.mocked(deleteVoice)).toHaveBeenCalledWith(
+			expect.anything(),
+			'voice_crede_soprano',
+			ORG_A_ID
+		);
+	});
+
+	it('reorderVoices must accept orgId to scope reorder to one org', () => {
+		const fn = reorderVoices as unknown as (db: D1Database, voiceIds: string[], orgId: string) => Promise<void>;
+		vi.mocked(reorderVoices).mockResolvedValue(undefined);
+
+		fn({} as D1Database, ['voice_crede_soprano', 'voice_crede_alto'], ORG_A_ID);
+		expect(vi.mocked(reorderVoices)).toHaveBeenCalledWith(
+			expect.anything(),
+			['voice_crede_soprano', 'voice_crede_alto'],
+			ORG_A_ID
+		);
+	});
+});
+
+// ============================================================================
+// Part 2: Cross-org isolation — getActiveVoices must filter by org
+// ============================================================================
+
+describe('getActiveVoices — must return only voices for the specified org (#252)', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('returns only org A voices when called with org A id', async () => {
+		// After fix: getActiveVoices(db, ORG_A_ID) returns only org A's voices
+		vi.mocked(getActiveVoices).mockImplementation(async (_db: D1Database, orgId?: string) => {
+			if (orgId === ORG_A_ID) return [ORG_A_SOPRANO, ORG_A_ALTO];
+			if (orgId === ORG_B_ID) return [ORG_B_SOPRANO];
+			// Current (broken) behavior: no orgId filtering, returns all
+			return [ORG_A_SOPRANO, ORG_A_ALTO, ORG_B_SOPRANO];
+		});
+
+		// The real function (before fix) ignores orgId → returns all 3
+		// After fix it returns only 2 for org A
+		const voices = await (getActiveVoices as any)({} as D1Database, ORG_A_ID);
+
+		// Must not contain org B's voice
+		expect(voices.some((v: Voice) => v.id === ORG_B_SOPRANO.id)).toBe(false);
+		expect(voices).toHaveLength(2);
+	});
+
+	it('returns different voices for org B than org A', async () => {
+		vi.mocked(getActiveVoices)
+			.mockResolvedValueOnce([ORG_A_SOPRANO, ORG_A_ALTO])
+			.mockResolvedValueOnce([ORG_B_SOPRANO]);
+
+		const orgAVoices = await (getActiveVoices as any)({} as D1Database, ORG_A_ID);
+		const orgBVoices = await (getActiveVoices as any)({} as D1Database, ORG_B_ID);
+
+		expect(orgAVoices).not.toEqual(orgBVoices);
+		expect(orgAVoices.map((v: Voice) => v.id)).not.toContain(ORG_B_SOPRANO.id);
+	});
+
+	it('two orgs can have voices with the same name independently', async () => {
+		// Both org A and org B have "Soprano" but they are separate DB rows with different IDs
+		vi.mocked(getActiveVoices)
+			.mockResolvedValueOnce([ORG_A_SOPRANO])
+			.mockResolvedValueOnce([ORG_B_SOPRANO]);
+
+		const orgAVoices = await (getActiveVoices as any)({} as D1Database, ORG_A_ID);
+		const orgBVoices = await (getActiveVoices as any)({} as D1Database, ORG_B_ID);
+
+		// Same display name, different IDs
+		expect(orgAVoices[0].name).toBe('Soprano');
+		expect(orgBVoices[0].name).toBe('Soprano');
+		expect(orgAVoices[0].id).not.toBe(orgBVoices[0].id);
+	});
+});
+
+// ============================================================================
+// Part 3: Cross-org isolation — toggleVoiceActive must not affect other orgs
+// ============================================================================
+
+describe('toggleVoiceActive — must reject cross-org requests (#252)', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('returns false when toggling a voice from a different org', async () => {
+		// Org B admin trying to toggle org A's voice
+		// After fix: toggleVoiceActive(db, id, flag, orgId) returns false if voice.org_id !== orgId
+		vi.mocked(toggleVoiceActive).mockImplementation(
+			async (_db: D1Database, id: string, _isActive: boolean, orgId?: string) => {
+				// voice_crede_soprano belongs to ORG_A_ID
+				if (id === 'voice_crede_soprano' && orgId !== ORG_A_ID) return false;
+				return true;
+			}
+		);
+
+		// Org B admin tries to deactivate org A's voice
+		const result = await (toggleVoiceActive as any)(
+			{} as D1Database,
+			'voice_crede_soprano',
+			false,
+			ORG_B_ID // wrong org
+		);
+
+		expect(result).toBe(false);
+	});
+
+	it('returns true when toggling own org voice', async () => {
+		vi.mocked(toggleVoiceActive).mockImplementation(
+			async (_db: D1Database, id: string, _isActive: boolean, orgId?: string) => {
+				if (id === 'voice_crede_soprano' && orgId === ORG_A_ID) return true;
+				return false;
+			}
+		);
+
+		const result = await (toggleVoiceActive as any)(
+			{} as D1Database,
+			'voice_crede_soprano',
+			false,
+			ORG_A_ID // correct org
+		);
+
+		expect(result).toBe(true);
+	});
+});
+
+// ============================================================================
+// Part 4: Cross-org isolation — deleteVoice must not cross org boundary
+// ============================================================================
+
+describe('deleteVoice — must reject cross-org delete (#252)', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('returns false when deleting a voice from a different org', async () => {
+		vi.mocked(deleteVoice).mockImplementation(
+			async (_db: D1Database, id: string, orgId?: string) => {
+				// voice_crede_soprano belongs to ORG_A_ID
+				if (id === 'voice_crede_soprano' && orgId !== ORG_A_ID) return false;
+				return true;
+			}
+		);
+
+		const result = await (deleteVoice as any)(
+			{} as D1Database,
+			'voice_crede_soprano',
+			ORG_B_ID // org B cannot delete org A's voice
+		);
+
+		expect(result).toBe(false);
+	});
+});
+
+// ============================================================================
+// Part 5: API endpoints must pass org context to DB functions
+// ============================================================================
+
+describe('POST /api/voices — must pass locals.org.id to createVoice (#252)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getAuthenticatedMember).mockResolvedValue(mockAdmin);
+		vi.mocked(assertAdmin).mockReturnValue(undefined);
+		vi.mocked(createVoice).mockResolvedValue(ORG_A_SOPRANO);
+	});
+
+	it('passes locals.org.id as orgId to createVoice', async () => {
+		const event = makeEvent({
+			org: { id: ORG_A_ID },
+			body: { name: 'Soprano', abbreviation: 'S', category: 'vocal' }
+		});
+
+		await POST(event);
+
+		// After fix: createVoice called with orgId in input
+		expect(createVoice).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ orgId: ORG_A_ID })
+		);
+	});
+
+	it('uses org B id when request comes from org B context', async () => {
+		const event = makeEvent({
+			org: { id: ORG_B_ID },
+			body: { name: 'Soprano', abbreviation: 'S', category: 'vocal' }
+		});
+
+		await POST(event);
+
+		expect(createVoice).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ orgId: ORG_B_ID })
+		);
+	});
+});
+
+describe('PATCH /api/voices/[id] — must pass locals.org.id to toggleVoiceActive (#252)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getAuthenticatedMember).mockResolvedValue(mockAdmin);
+		vi.mocked(assertAdmin).mockReturnValue(undefined);
+		vi.mocked(toggleVoiceActive).mockResolvedValue(true);
+	});
+
+	it('passes locals.org.id as orgId to toggleVoiceActive', async () => {
+		const event = makeEvent({
+			org: { id: ORG_A_ID },
+			body: { isActive: false },
+			params: { id: 'voice_crede_soprano' },
+			method: 'PATCH'
+		});
+
+		await PATCH(event);
+
+		// After fix: toggleVoiceActive called with orgId
+		expect(toggleVoiceActive).toHaveBeenCalledWith(
+			expect.anything(),
+			'voice_crede_soprano',
+			false,
+			ORG_A_ID
+		);
+	});
+});
+
+describe('DELETE /api/voices/[id] — must pass locals.org.id to deleteVoice (#252)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getAuthenticatedMember).mockResolvedValue(mockAdmin);
+		vi.mocked(assertAdmin).mockReturnValue(undefined);
+		vi.mocked(deleteVoice).mockResolvedValue(true);
+	});
+
+	it('passes locals.org.id as orgId to deleteVoice', async () => {
+		const event = makeEvent({
+			org: { id: ORG_A_ID },
+			params: { id: 'voice_crede_soprano' },
+			method: 'DELETE'
+		});
+
+		await DELETE(event);
+
+		// After fix: deleteVoice called with orgId
+		expect(deleteVoice).toHaveBeenCalledWith(
+			expect.anything(),
+			'voice_crede_soprano',
+			ORG_A_ID
+		);
+	});
+});
+
+describe('POST /api/voices/reorder — must pass locals.org.id to reorderVoices (#252)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getAuthenticatedMember).mockResolvedValue(mockAdmin);
+		vi.mocked(assertAdmin).mockReturnValue(undefined);
+		vi.mocked(reorderVoices).mockResolvedValue(undefined);
+		vi.mocked(getAllVoicesWithCounts).mockResolvedValue([]);
+	});
+
+	it('passes locals.org.id as orgId to reorderVoices', async () => {
+		const event = makeEvent({
+			org: { id: ORG_A_ID },
+			body: { voiceIds: ['voice_crede_alto', 'voice_crede_soprano'] }
+		});
+
+		await REORDER(event);
+
+		// After fix: reorderVoices called with orgId
+		expect(reorderVoices).toHaveBeenCalledWith(
+			expect.anything(),
+			['voice_crede_alto', 'voice_crede_soprano'],
+			ORG_A_ID
+		);
+	});
+
+	it('passes locals.org.id to getAllVoicesWithCounts for the return value', async () => {
+		const event = makeEvent({
+			org: { id: ORG_A_ID },
+			body: { voiceIds: ['voice_crede_soprano'] }
+		});
+
+		await REORDER(event);
+
+		// After fix: getAllVoicesWithCounts called with orgId to return scoped list
+		expect(getAllVoicesWithCounts).toHaveBeenCalledWith(
+			expect.anything(),
+			ORG_A_ID
+		);
+	});
+});

--- a/apps/vault/src/tests/routes/api/voices.spec.ts
+++ b/apps/vault/src/tests/routes/api/voices.spec.ts
@@ -121,6 +121,7 @@ describe('POST /api/voices', () => {
 
 		expect(response.status).toBe(201);
 		expect(createVoice).toHaveBeenCalledWith({}, {
+			orgId: 'test-org',
 			name: 'Tenor',
 			abbreviation: 'T',
 			category: 'vocal',
@@ -150,6 +151,7 @@ describe('POST /api/voices', () => {
 
 		expect(response.status).toBe(201);
 		expect(createVoice).toHaveBeenCalledWith({}, {
+			orgId: 'test-org',
 			name: 'Tenor',
 			abbreviation: 'T',
 			category: 'vocal',
@@ -272,8 +274,8 @@ describe('PATCH /api/voices/[id]', () => {
 		const response = await PATCH(event as Parameters<typeof PATCH>[0]);
 
 		expect(response.status).toBe(200);
-		expect(toggleVoiceActive).toHaveBeenCalledWith({}, 'voice-1', false);
-		expect(getVoiceById).toHaveBeenCalledWith({}, 'voice-1');
+		expect(toggleVoiceActive).toHaveBeenCalledWith({}, 'voice-1', false, 'test-org');
+		expect(getVoiceById).toHaveBeenCalledWith({}, 'voice-1', 'test-org');
 	});
 
 	it('toggles voice to active', async () => {
@@ -289,7 +291,7 @@ describe('PATCH /api/voices/[id]', () => {
 		const response = await PATCH(event as Parameters<typeof PATCH>[0]);
 
 		expect(response.status).toBe(200);
-		expect(toggleVoiceActive).toHaveBeenCalledWith({}, 'voice-1', true);
+		expect(toggleVoiceActive).toHaveBeenCalledWith({}, 'voice-1', true, 'test-org');
 	});
 
 	it('returns 400 if isActive is not a boolean', async () => {
@@ -356,7 +358,7 @@ describe('DELETE /api/voices/[id]', () => {
 		expect(response.status).toBe(200);
 		const data = await response.json() as { success: boolean };
 		expect(data.success).toBe(true);
-		expect(deleteVoice).toHaveBeenCalledWith({}, 'voice-1');
+		expect(deleteVoice).toHaveBeenCalledWith({}, 'voice-1', 'test-org');
 	});
 
 	it('returns 404 if voice not found', async () => {
@@ -416,8 +418,8 @@ describe('POST /api/voices/reorder', () => {
 		const response = await REORDER(event);
 
 		expect(response.status).toBe(200);
-		expect(reorderVoices).toHaveBeenCalledWith({}, ['voice-2', 'voice-1', 'voice-3']);
-		expect(getAllVoicesWithCounts).toHaveBeenCalled();
+		expect(reorderVoices).toHaveBeenCalledWith({}, ['voice-2', 'voice-1', 'voice-3'], 'test-org');
+		expect(getAllVoicesWithCounts).toHaveBeenCalledWith({}, 'test-org');
 	});
 
 	it('returns 400 if voiceIds is missing', async () => {


### PR DESCRIPTION
## Summary

- Add `org_id TEXT NOT NULL` to `voices` table with `UNIQUE(org_id, name)` constraint via D1-safe migration 0043
- All 9 DB functions in `voices.ts` now accept `orgId` parameter with org-scoped queries
- Update all API routes and page loaders to pass `locals.org.id`
- Org-scoped primary voice triggers (matching the sections pattern from migration 0037)
- Migration seeds voices for all existing organizations via `CROSS JOIN` and maps `member_voices`/`invite_voices` to org-scoped voice IDs

## Test plan

- [x] 18 new org-scoped voice tests pass (6 previously failing now green)
- [x] All 1265 existing tests pass (99 files)
- [x] 0 type errors across full codebase
- [x] Migration applies cleanly on local D1
- [ ] Apply migration 0043 on remote D1 after merge

Fixes #252

Co-Authored-By: