### PR TITLE
feat(i18n): add Latvian translations for all 5 guide pages

### DIFF
--- a/apps/vault/src/lib/content/guides/admin-lv.md
+++ b/apps/vault/src/lib/content/guides/admin-lv.md
@@ -1,0 +1,192 @@
+# Administratora rokasgrāmata
+
+_Pārskats par lomām un tiesībām — kurš ko var darīt_
+
+---
+
+## Ievads
+
+Polyphony Vault ir veidots uz lomu pamata. Tas nozīmē, ka katram lietotājam ir noteiktas tiesības atbilstoši viņa uzdevumam korī.
+
+**Ņem vērā:** Vienai personai var būt **vairākas lomas vienlaikus**. Piemēram, kora vadītājs var būt vienlaikus gan administrators, gan nošu krājuma pārzinis. Tiesības summējas — ja viena loma atļauj kādu darbību, tā ir atļauta, pat ja cita loma to tieši nemin.
+
+---
+
+## Lomu apraksti
+
+### Īpašnieks (Owner)
+
+Vides izveidotājs un vadības loceklis. **Pats nenodarbojas ar nošu vai mēģinājumu pārvaldīšanu** — vajadzības gadījumā piešķir sev atbilstošās lomas.
+
+**Uzdevumi:**
+
+- Piešķir citiem dalībniekiem lomas (t.sk. citus īpašniekus)
+- Pārvalda lietotnes tehniskos iestatījumus
+- Atbild par visas vides darbību
+- Vajadzības gadījumā var piešķirt sev administratora, bibliotekāra vai diriģenta lomu
+
+**Kam piemērota:** Kora priekšsēdētājs, valdes priekšsēdētājs vai IT atbalsts.
+
+**NB:** Katrā korī vienmēr jābūt vismaz vienam aktīvam lietotājam ar īpašnieka tiesībām.
+
+---
+
+### Administrators (Admin)
+
+Kārto dalībnieku sarakstu. **Nenodarbojas ar nošu pievienošanu** — tā ir atsevišķa loma.
+
+**Uzdevumi:**
+
+- Pievieno jaunus dziedātājus sarakstam un nosūta viņiem uzaicinājumus
+- Piešķir dalībniekiem lomas (izņemot īpašnieka lomu — to var mainīt tikai īpašnieks)
+- Vajadzības gadījumā izņem dalībniekus no saraksta
+
+**Kam piemērota:** Kora sekretārs, valdes loceklis vai kora vecākais.
+
+**Padoms:** Ja administrators nodarbojas arī ar notīm, viņš var vienkārši pievienot sev arī bibliotekāra lomu.
+
+---
+
+### Bibliotekārs (Librarian)
+
+Rūpējas par nošu krājuma kārtību.
+
+**Uzdevumi:**
+
+- Augšupielādē jaunus darbus un notis (PDF)
+- Pievieno darbiem informāciju (komponists, aranžētājs, licence)
+- Dzēš novecojušus vai kļūdainus failus
+
+**Kam piemērota:** Nošu krājuma pārzinis, arhivārs vai diriģenta palīgs.
+
+---
+
+### Diriģents (Conductor)
+
+Kārto mēģinājumu grafiku un seko līdzi dalībai.
+
+**Uzdevumi:**
+
+- Izveido kalendārā mēģinājumus un koncertus ("Events")
+- Maina pasākumu laikus un informāciju
+- Atzīmē klātesošos un kavētājus
+
+**Kam piemērota:** Galvenais diriģents, kordiriģents vai palīgdiriģents.
+
+---
+
+### Balsu grupas vadītājs (Section Leader)
+
+Palīdz uzskaitīt apmeklējumu.
+
+**Uzdevumi:**
+
+- Atzīmē dalībnieku apmeklējumu mēģinājumos
+
+**Kam piemērota:** Soprānu, altu, tenoru vai basu vecākais.
+
+---
+
+## Tiesību tabula
+
+Ātrais pārskats, kādas darbības ir atļautas dažādām lomām:
+
+| Darbība                              | Īpašnieks | Admins | Bibliotekārs | Diriģents | Balsu gr. vad. | Parasts dziedātājs |
+| :----------------------------------- | :-------: | :----: | :----------: | :-------: | :------------: | :----------------: |
+| Nošu skatīšana un lejupielāde       |     ✅    |   ✅   |      ✅      |     ✅    |       ✅       |         ✅         |
+| **Nošu pievienošana un mainīšana**   |     ❌    |   ❌   |      ✅      |     ❌    |       ❌       |         ❌         |
+| **Dalībnieku uzaicināšana un pārvaldīšana** | ✅ |   ✅   |      ❌      |     ❌    |       ❌       |         ❌         |
+| **Lomu mainīšana**                   |     ✅    |  ✅¹   |      ❌      |     ❌    |       ❌       |         ❌         |
+| **Mēģinājumu pievienošana kalendāram** |   ❌    |   ❌   |      ❌      |     ✅    |       ❌       |         ❌         |
+| **Apmeklējuma atzīmēšana**           |     ❌    |   ❌   |      ❌      |     ✅    |       ✅       |         ❌         |
+| **Iestatījumu pārvaldīšana**         |     ✅    |   ✅   |      ❌      |     ❌    |       ❌       |         ❌         |
+| Vides dzēšana                        |     ✅    |   ❌   |      ❌      |     ❌    |       ❌       |         ❌         |
+
+**Paskaidrojumi:**
+
+- ✅ = Atļauts
+- ❌ = Nav atļauts
+- ¹ Admins var mainīt visas lomas **izņemot īpašnieka lomu** — to var mainīt tikai īpašnieks.
+- **Parasts dziedātājs** = Katrs pieteicies dalībnieks, kuram nav nevienas papildlomas.
+- **Īpašnieks** var pievienot sev lomas (Bibliotekārs, Diriģents utt.), ja nepieciešamas attiecīgās tiesības.
+- **Individuālās atbildības uzticēšana (Trust Individual Responsibility):** Ja šis iestatījums ir ieslēgts, arī parastie dziedātāji var paši atzīmēt savu RSVP un apmeklējumu. Pēc noklusējuma tas ir atļauts tikai īpašniekiem, administratoriem, diriģentiem un balsu grupas vadītājiem.
+
+---
+
+## Kā...
+
+### ...pievienot jaunu dziedātāju?
+
+Dalībnieka pievienošana notiek divos soļos:
+
+1. **Admins** (vai īpašnieks) izvēlnē izvēlas **"Members"** un noklikšķina **"Add Roster Member"**.
+2. Ievada dziedātāja vārdu un piešķir atbilstošu balsu grupu (piem., "Soprāns" vai "Bass"). Saglabā.
+3. Atver tikko pievienoto dalībnieka profilu un noklikšķina **"Send Invitation"**.
+   > Dalībnieks saņem unikālu uzaicinājuma saiti, ar kuru var reģistrēties un piekļūt notīm. E-pasta adresi nav nepieciešams zināt uzaicinājuma brīdī — dalībnieks vispirms tiek pievienots sarakstam, uzaicinājums tiek nosūtīts vēlāk.
+
+### ...pievienot jaunu noti?
+
+1. **Bibliotekārs** atver **"Works"**.
+2. Izvēlas **"Add Work"** (pievienot darbu).
+3. Augšupielādē PDF failu un aizpilda nepieciešamos datus (nosaukums, autors).
+
+### ...organizēt mēģinājumu?
+
+1. **Diriģents** atver **"Events"**.
+2. Izveido jaunu pasākumu, norādot datumu un laiku.
+3. Pēc mēģinājuma atver to pašu pasākumu un atzīmē, kurš bija klāt.
+
+### ...pārvaldīt iestatījumus?
+
+**Īpašnieks** vai **administrators** var piekļūt iestatījumu lapai (**"Settings"**). No turienes var:
+
+- Mainīt noklusējuma pasākuma ilgumu
+- Noteikt kora noklusējuma valodu un laika joslu
+- Ieslēgt/izslēgt **Individuālās atbildības uzticēšanu** — ja tā ir ieslēgta, dalībnieki paši var pārvaldīt savu RSVP un apmeklējumu.
+
+---
+
+## Jaunie saraksta dalībnieki (roster-only)
+
+Dziedātājus var pievienot sarakstam **pirms** uzaicinājuma nosūtīšanas. Šādu dalībnieku sauc par _saraksta dalībnieku_ (roster-only):
+
+- Viņš ir redzams dalības statistikā un pasākumu sarakstos
+- Viņš **nevar pieteikties** pirms uzaicinājuma nosūtīšanas un reģistrācijas pabeigšanas
+- Uzaicinājuma nosūtīšanas brīdī viņam var iepriekš piešķirt lomas — tās aktivizējas uzreiz pēc reģistrācijas
+
+Šis divpakāpju modelis ļauj uzturēt kora sarakstu kārtībā arī pirms visu dziedātāju reģistrācijas pabeigšanas.
+
+---
+
+## Pirmie soļi jaunajam pārvaldniekam
+
+Ja tikko esi saņēmis administratora vai īpašnieka tiesības, iesakām sākt šādi:
+
+1. **Pārskatiet savas lomas.**
+   Dodies uz lapu "Members" un atrodi sarakstā savu vārdu. Pārliecinies, ka tev ir visas nepieciešamās lomas sava darba veikšanai.
+
+2. **Pievieno kora dalībniekus sarakstam.**
+   Izmanto "Add Roster Member" pogu, lai pievienotu dziedātājus pa balsu grupām. Pēc tam nosūti viņiem uzaicinājumus caur "Send Invitation".
+
+3. **Iecel palīgus.**
+   Atrodi sarakstā cilvēkus, kas palīdzēs pārvaldīt notis vai mēģinājumus, un pievieno viņiem atbilstošās lomas (piem., _Admin_ vai _Librarian_). Tam noklikšķini uz lomas pogas pie dalībnieka vārda.
+
+4. **Sakārto balsu grupas.**
+   Pārliecinies, ka katram dziedātājam ir atzīmēta pareizā balsu grupa (piem., Soprāns 1, Tenors 2). Tas ir svarīgi, kad sāksiet atzīmēt apmeklējumu mēģinājumos.
+
+---
+
+## Biežāk uzdotie jautājumi
+
+**Kāpēc es nevaru augšupielādēt notis?**
+Visticamāk tev trūkst **Bibliotekāra (Librarian)** lomas. Lūdz administratoram vai īpašniekam to pievienot.
+
+**Kāpēc es neredzu "Add Roster Member" pogu?**
+Tev trūkst **Administratora (Admin)** lomas. Tikai administratori un īpašnieki var pievienot dalībniekus.
+
+**Vai es varu noņemt dalībniekam lomu?**
+Jā. Lapā "Members" noklikšķinot uz aktīvās lomas (piem., zilā "Admin" poga), tā kļūst neaktīva un tiesības tiek noņemtas nekavējoties.
+
+---
+
+_Rokasgrāmata atjaunināta: 20.02.2026_

--- a/apps/vault/src/lib/content/guides/conductor-lv.md
+++ b/apps/vault/src/lib/content/guides/conductor-lv.md
@@ -1,0 +1,137 @@
+# Diriģenta rokasgrāmata
+
+_Rokasgrāmata mēģinājumu un koncertu pārvaldīšanai_
+
+---
+
+## Ievads
+
+Diriģenta (vai kordiriģenta) loma Polyphony Vault ir saistīta ar pasākumu plānošanu un apmeklējuma pārvaldīšanu. Tavi galvenie rīki ir pasākumu izveide, programmas sastādīšana un apmeklējuma atzīmēšana.
+
+**Piezīme:** Ja tu piederi vairākām organizācijām, augšējā labajā stūra izvēlnē vari izvēlēties, kuras organizācijas datus pārvaldīt.
+
+---
+
+## Tavas tiesības
+
+Kā diriģentam tev ir šādas īpašās iespējas:
+
+- **Pasākumu izveide:** Vari pievienot kalendāram mēģinājumus, koncertus, nometnes un festivālus.
+- **Pasākumu pārvaldīšana:** Vari mainīt pasākumu laikus, vietas, aprakstus un programmas.
+- **Pasākumu dzēšana:** Vari noņemt pasākumus no kalendāra.
+- **Apmeklējuma atzīmēšana:** Vari atzīmēt, kuri dziedātāji bija klāt un kuri nebija.
+- **Programmas sastādīšana:** Vari saistīt pasākumus ar nošu krājumā esošajiem darbiem.
+- **Visas dziedātāja tiesības:** Vari skatīt notis, lejupielādēt un atzīmēt savu dalību.
+
+**Ko tu nevari darīt:**
+
+- Tu nevari pievienot notis krājumam (tas ir bibliotekāra darbs).
+- Tu nevari pārvaldīt dalībnieku sarakstu (tas ir administratora darbs).
+- Tu nevari mainīt dalībnieku tiesības vai lomas.
+
+---
+
+## Kā...
+
+### ...pievienot jaunu pasākumu?
+
+1. Izvēlnē izvēlies **"Events"** (pasākumi).
+2. Noklikšķini uz pogas **"Create Event"** (izveidot pasākumu).
+3. Aizpildi nepieciešamos laukus:
+   - **Title** (nosaukums): Pasākuma nosaukums
+   - **Type** (veids): Izvēlies atbilstošu:
+     - **Rehearsal** (mēģinājums) — parastie treniņi
+     - **Concert** (koncerts) — uzstāšanās publikai
+     - **Retreat** (nometne) — garāki pasākumi
+     - **Festival** (festivāls) — konkursi un festivāli
+   - **Date & Time** (datums un laiks): Sākuma laiks
+   - **Duration** (ilgums): Dienas, stundas un minūtes
+   - **Location** (vieta): Mēģinājumu zāle, koncertzāle u.c.
+   - **Description** (apraksts): Papildinformācija (neobligāts)
+
+**Padoms:** Vari izveidot atkārtotus pasākumus (reizi nedēļā vai ik pa divām nedēļām) un izvēlēties, kurus datumus izlaist.
+
+### ...sastādīt pasākuma programmu?
+
+Vari saistīt pasākumu ar konkrētiem darbiem, lai dziedātāji zinātu, kādas notis ņemt līdzi.
+
+1. Atver izveidoto pasākumu (noklikšķini uz tā nosaukuma kalendārā).
+2. Atrodi sadaļu **"Event Repertoire"** (pasākuma programma).
+3. Noklikšķini **"Add Work"** (pievienot darbu).
+4. Izvēlies darbu no saraksta vai izmanto meklēšanu.
+5. Izvēlies atbilstošos izdevumus (notis) šim darbam.
+
+**Rezultāts:** Dziedātāji pie pasākuma redzēs, kādas notis ir nepieciešamas, un varēs tās tieši atvērt/lejupielādēt.
+
+### ...skatīt un pārvaldīt dalību?
+
+Pasākuma lapā redzēsi pilnu dalības pārskatu:
+
+1. **"My Participation"** — tavs pašreizējais statuss
+2. **"Participation Overview"** — visu dalībnieku RSVP atbildes
+   - **Going** (ieradīsies) — apstiprinājis dalību
+   - **Not Going** (neieradīsies) — paziņojis par neierašanos
+   - **Maybe** (varbūt) — vēl nav pārliecināts
+   - **Late** (kavēsies) — ieradīsies, bet ar kavēšanos
+   - **No Response** — vēl nav atbildējis
+
+### ...atzīmēt apmeklējumu?
+
+Pēc pasākuma (vai tā laikā):
+
+1. Atver pasākumu no kalendāra.
+2. Sadaļā **"Participation Overview"** noklikšķini **"Record Attendance"**.
+3. Redzēsi visu dalībnieku sarakstu:
+   - **Present** (klāt) — atzīmē zaļu ķeksīti
+   - **Absent** (nebija) — atstāj neatzīmētu vai noņem ķeksīti
+4. Vari veikt arī kopīgas izmaiņas (visus klātesošos uzreiz).
+5. Noklikšķini **"Save"** lai saglabātu izmaiņas.
+
+**Piezīme:** Tavi atzīmētie dati ir galīgā patiesība (tie pārraksta automātiskās RSVP prognozes).
+
+### ...mainīt vai dzēst pasākumu?
+
+Pasākuma lapā (ja tev ir tiesības):
+
+1. **Mainīšana:** Noklikšķini **"Edit Event"** un maini nepieciešamos laukus.
+2. **Dzēšana:** Noklikšķini **"Delete Event"** — lietotne prasīs apstiprinājumu.
+
+---
+
+## Noderīgi padomi
+
+### Plānošanai
+- **RSVP termiņš:** Mudiniet dziedātājus atzīmēt savu ierašanos pirms pasākuma. Tas dod labāku pārskatu par sastāvu.
+- **Programma laicīgi:** Pievieno pasākuma programmu pēc iespējas agrāk, lai dziedātāji varētu iepazīties ar notīm.
+- **Atkārtoti mēģinājumi:** Izmanto atkārtotu pasākumu funkciju regulāriem mēģinājumiem.
+
+### Apmeklējumam
+- **Reāllaikā:** Apmeklējumu vari atzīmēt arī mēģinājuma laikā (ne tikai pēc tam).
+- **Pa sekcijām:** Dalībnieku saraksts ir sagrupēts pa balsu grupām.
+- **Ātrā atzīmēšana:** Izmanto kopīgās izmaiņas, ja lielākā daļa bija klāt.
+
+### Repertuāram
+- **Vairāki izdevumi:** Pasākumam vari pievienot vairākus izdevumus no viena darba (piem., kora partitūra un klavierizvilkums).
+- **Pa sekcijām:** Vari izvēlēties, kuri izdevumi ir kurām balsu grupām.
+
+---
+
+## BUJ
+
+**Vai es varu mainīt citu dalībnieku RSVP atbildes?**
+Nē, bet vari atzīmēt faktisko apmeklējumu. RSVP ir pašu dalībnieku atbildība.
+
+**Kāpēc es neredzu "Create Event" pogu?**
+Iespējamie iemesli:
+- Tev nav diriģenta lomas
+- Tu esi izvēlējies nepareizo organizāciju (skati augšējo labo pogu)
+
+**Vai es varu pārcelt pasākumu?**
+Jā, atver pasākumu un noklikšķini "Edit Event". Vari mainīt datumu, laiku un ilgumu.
+
+**Kā es varu uzzināt, kurš vēl nav atbildējis uz RSVP?**
+Pasākuma lapā "Participation Overview" rāda visus dalībniekus. "No Response" atzīmē tos, kuri vēl nav atbildējuši.
+
+---
+
+_Rokasgrāmata atjaunināta: 20.02.2026_

--- a/apps/vault/src/lib/content/guides/librarian-lv.md
+++ b/apps/vault/src/lib/content/guides/librarian-lv.md
@@ -1,0 +1,77 @@
+# Bibliotekāra rokasgrāmata
+
+_Rokasgrāmata nošu krājuma pārvaldīšanai un uzturēšanai_
+
+---
+
+## Ievads
+
+Bibliotekārs jeb **Librarian** ir atslēgas persona, kas atbild par to, lai korim vienmēr būtu pieejamas un sakārtotas notis. Tavs uzdevums ir digitālā nošu krājuma papildināšana un pārvaldīšana.
+
+---
+
+## Tavas tiesības
+
+Kā bibliotekāram tev ir šādas īpašās iespējas:
+
+- **Nošu pievienošana:** Vari augšupielādēt jaunus darbus un izdevumus (PDF failus).
+- **Informācijas mainīšana:** Vari labot darbu nosaukumus, autoru vārdus un citus metadatus.
+- **Dzēšana:** Vari noņemt kļūdainus failus vai dublikātus.
+- **Visas dziedātāja tiesības:** Protams, vari arī pats skatīt un lejupielādēt notis.
+
+**Ko tu nevari darīt:**
+
+- Tu nevari uzaicināt jaunus dalībniekus vai mainīt viņu lomas (tas ir Administratora darbs).
+- Tu nevari pārvaldīt mēģinājumu kalendāru (tas ir Diriģenta darbs).
+
+---
+
+## Kā...
+
+### ...pievienot jaunu darbu (Work)?
+
+1. Izvēlnē izvēlies **"Works"**.
+2. Noklikšķini uz pogas **"Add Work"**.
+3. Ievadi darba pamatdatus:
+   - **Nosaukums (Title):** Darba nosaukums oriģinālvalodā.
+   - **Komponists (Composer):** Autoru vārdi.
+
+### ...pievienot nošu failu (Edition)?
+
+Polyphony izšķir "Darbu" (piem., "Pērts - Ukuaru valss") un tā konkrētu "Izdevumu" jeb noti (piem., "Sieviešu kora aranžējums PDF"). Vienam darbam var būt vairākas dažādas versijas.
+
+1. Atver darbu, kuram vēlies pievienot noti.
+2. Noklikšķini **"Add Edition"**.
+3. Izvēlies izdevuma **veidu**:
+   - **Full Score** — pilna partitūra (visas balsis kopā)
+   - **Vocal Score** — vokālā partitūra (melodijas ar klaviera pavadījumu)
+   - **Part** — vienas balsu grupas partija (piem., tikai soprāns)
+   - **Reduction** — klavierizvilkums
+   - **Audio** — audio fails
+   - **Video** — video ieraksts (piem., YouTube saite)
+   - **Supplementary** — papildmateriāls (teksts, tulkojums, vingrinājumu rokasgrāmata u.c.)
+4. Atzīmē **licenci**:
+   - **Public Domain** — autortiesības beigušās, brīva izmantošana. _Vienmēr pārbaudi pats, pirms norādi šo statusu!_
+   - **Licensed** — korim ir licence šī darba izmantošanai
+   - **Owned** — koris ir fiziskā oriģināla īpašnieks
+5. Saglabā. Notis tagad ir redzamas kora dalībniekiem.
+
+### ...dzēst noti vai darbu?
+
+Polyphony izšķir **Darba (Work)** un **Izdevuma (Edition)** dzēšanu:
+
+- **Izdevuma dzēšana:** Atver darbu → atrodi atbilstošo izdevumu → noklikšķini "Edit" → "Delete Edition". Dzēš tikai šo konkrēto failu/versiju, darbs paliek.
+- **Darba dzēšana:** Atver darbu → noklikšķini "Edit Work" → "Delete Work". Dzēš darbu **kopā ar visiem izdevumiem**. Pirms tam pārliecinies, ka visi izdevumi ir pārvietoti vai dzēsti.
+
+---
+
+## Laba prakse un ieteikumi
+
+- **Failu nosaukumi:** Pirms augšupielādes pārliecinies, ka PDF faila nosaukums ir saprotams (piem., `Ukuaru_valss_Soprans.pdf`), lai gan sistēma ļauj vēlāk mainīt nosaukumu.
+- **Metadati:** Jo precīzāk ievadīsi komponista un aranžētāja vārdus, jo vienkāršāk dziedātājiem būs izmantot meklēšanu.
+- **Dublikāti:** Pirms jauna darba pievienošanas pārbaudi ar meklēšanu, vai tas jau nepastāv.
+- **Licence:** Vienmēr atzīmē pareizo licences veidu — tas ir svarīgi autortiesību prasību ievērošanai.
+
+---
+
+_Rokasgrāmata atjaunināta: 20.02.2026_

--- a/apps/vault/src/lib/content/guides/section-leader-lv.md
+++ b/apps/vault/src/lib/content/guides/section-leader-lv.md
@@ -1,0 +1,60 @@
+# Balsu grupas vadītāja rokasgrāmata
+
+_Rokasgrāmata apmeklējuma atzīmēšanai_
+
+---
+
+## Ievads
+
+Balsu grupas vadītājs (**Section Leader**) ir diriģenta labā roka apmeklējuma kontrolē. Tavs galvenais uzdevums ir gādāt par to, lai mēģinājumu apmeklējums tiktu pareizi reģistrēts.
+
+---
+
+## Tavas tiesības
+
+Kā balsu grupas vadītājam tev ir viena galvenā papildiespēja salīdzinājumā ar parastu dziedātāju:
+
+- **Apmeklējuma atzīmēšana:** Vari atzīmēt visu kora dalībnieku apmeklējumu mēģinājumos — šīs tiesības attiecas uz visu kori, ne tikai uz tavu balsu grupu.
+
+**Ko tu nevari darīt:**
+
+- Tu nevari izveidot jaunus pasākumus (tas ir Diriģenta darbs).
+- Tu nevari augšupielādēt notis vai uzaicināt jaunus dalībniekus.
+
+---
+
+## Kā atzīmēt apmeklējumu?
+
+### Atsevišķa pasākuma apmeklējuma atzīmēšana
+
+Kad mēģinājums ir sācies vai beidzies:
+
+1. Izvēlnē izvēlies **"Events"**.
+2. Noklikšķini uz attiecīgā mēģinājuma vai koncerta.
+3. Ritini lejup līdz sadaļai **"Participation"** — apmeklējuma atzīmēšana ir šeit integrēta, atsevišķas cilnes nav.
+4. Meklē dalībniekus sarakstā.
+5. Atzīmē statusu:
+   - **Present (Klāt):** Zaļš ķeksītis.
+   - **Late (Kavējās):** Dzeltens pulkstenis.
+   - **Absent (Nebija):** Sarkans krustiņš.
+
+Tavi atzīmētie dati tiek saglabāti nekavējoties un ir redzami diriģentam un administratoriem statistikas vajadzībām.
+
+### Vairāku pasākumu apmeklējuma skats (Roster)
+
+Lai pārskatītu vairāku mēģinājumu apmeklējumu, izmanto **Roster** skatu:
+
+1. Izvēlnē izvēlies **"Roster"**.
+2. Šeit redzēsi visu dalībnieku apmeklējumu visos sezonas pasākumos vienā tabulā.
+3. Vari atzīmēt apmeklējumu tieši no tabulas, noklikšķinot uz attiecīgās šūnas.
+
+---
+
+## Ieteikumi
+
+- **Pārbaudi RSVP:** Skati, kurš ir atzīmējis, ka ieradīsies. Ja kāds "Solīja ierasties", bet zālē nav, noteikti atzīmē viņu kā neierādījušos.
+- **Operativitāte:** Visvieglāk ir atzīmēt apmeklējumu mēģinājuma sākumā vai pārtraukumā, lai vēlāk neaizmirstas.
+
+---
+
+_Rokasgrāmata atjaunināta: 20.02.2026_

--- a/apps/vault/src/lib/content/guides/singer-lv.md
+++ b/apps/vault/src/lib/content/guides/singer-lv.md
@@ -1,0 +1,130 @@
+# Dziedataja rokasgramata
+
+_Rokasgramata koristam ikdienas lietosanai_
+
+---
+
+## Ievads
+
+Laipni ludzam Polyphony! Sī ir tava kora digitala maja, kur atradīsi notis un meginajumu informaciju. Sī rokasgramata palidzes tev orienteties vidē.
+
+**Piezīme:** Ja tu piederi vairakam kora organizacijam, augšeja labaja stūra izvēlnē vari izvēlēties, kuras organizacijas datus skatīt.
+
+---
+
+## Ko tu vari darīt?
+
+Katrs pieteicies kora dalībnieks var:
+
+- **Skatīt notis:** Parlūkot digitalo nosupamatu krājumu.
+- **Lejupielādēt:** Saglabāt PDF notis savā datora vai planšetē.
+- **Skatīt kalendāru:** Redzēt gaidāmās meginajumus un koncertus.
+- **Apstiprināt dalību (RSVP):** Paziņot, vai varēsi apmeklēt meginajumu.
+- **Skatīt sastāvu:** Redzēt, kas vēl pieder korim.
+- **Pārvaldīt savu profilu:** Mainīt savus datus un iestatījumus.
+
+---
+
+## Ka...
+
+### ...atrast notis?
+
+1. Izvēlnē izvēlies **"Works"** (darbi/skaņdarbi).
+2. Atvērtajā sarakstā meklē vajadzīgo darbu (izmanto meklēšanas lauku augšā).
+3. Nokliksini uz darba nosaukuma, lai redzētu visus tā izdevumus.
+4. Pie katra izdevuma redzēsi pogas:
+   - **"View"** - atvert PDF parlūkprogrammā
+   - **"Download"** - lejupielādēt PDF datorā
+5. Dažiem darbiem var būt arī ārējās saites (piem., YouTube videoklipi).
+
+**Padoms:** Izdevumi var būt dažādu veidu (kora partitura, klavierpavadījums, balsu partija utt.).
+
+### ...paziņot par ierašanos uz meginajumu (RSVP)?
+
+Ir ļoti svarīgi, lai diriģents zinatu, cik dziedataju ieradīsies uz meginajumu.
+
+1. Izvēlnē izvēlies **"Events"** (pasākumi).
+2. Redzēsi gaidāmo pasākumu sarakstu.
+3. Pie katra pasākuma ir pogas:
+   - **"Going" (Ieradīšos):** Apstiprini dalību.
+   - **"Not Going" (Neieradīšos):** Paziņo par neierašanos.
+   - **"Maybe" (Varbūt):** Ja vēl neesi pārliecinats.
+   - **"Late" (Kavēšos):** Ieradīsies, bet ar kavēšanos.
+4. Nokliksini uz atbilstošas pogas — tava izvēle tiks automatiski saglabāta.
+
+### ...skatīt sastāvu?
+
+1. Nokliksini augšēja kreisajā stūrī uz sava **kora nosaukuma** — tas aizvedīs tevi uz sakumlapu.
+2. Redzēsi visus kora dalībniekus un vinu dalību pasākumos.
+3. Vari filtrēt dalībniekus pēc balsu grupām.
+
+### ...mainīt savus datus?
+
+1. Nokliksini augšēja labajā stūrī uz sava vārda.
+2. Izvēlies **"Profile"** (profils).
+3. Šeit redzēsi savus:
+   - Balsu grupu (piem., soprāns, alts)
+   - Kontaktinformaciju
+   - Valodas iestatījumus
+   - Organizacijas piederību
+
+---
+
+## Lomas un tiesības
+
+### Parasts dziedatājs
+
+- Skatanotis un lejupielādē
+- Paziņo par savu dalību pasākumos
+- Redz sastāvu un pasākumu kalendāru
+
+### Bibliotekārs (Librarian)
+
+- Augšupielādē jaunas notis
+- Pārvalda nosupamatu krājumu
+
+### Diriģents (Conductor)
+
+- Izveido jaunus pasākumus
+- Atzīmē apmeklējumu meginajumos
+
+### Balsu grupas vadītājs (Section Leader)
+
+- Atzīmē savas balsu grupas apmeklējumu
+
+### Administrators (Admin)
+
+- Uzaicina jaunus dalībniekus
+- Pārvalda dalībnieku datus
+
+### Īpašnieks (Owner)
+
+- Pārvalda iestatījumus un dalībniekus
+- Var pievienot sev citas lomas (piem., Bibliotekārs, Diriģents)
+
+---
+
+## BUJ
+
+**Kapēc es neredzu nevienu noti?**
+Iespējamie iemesli:
+
+- Administrators tevi vēl nav pievienojis organizacijai
+- Bibliotekārs vēl nav augšupielādējis notis
+- Tu esi izvēlējies nepareizo organizaciju (skati augšējo labo pogu)
+
+**Vai es varu pats augšupielādēt notis?**
+Nē, nosupamatu pievienošanas tiesības ir tikai bibliotekāram. Ja tev ir digitālā nots, nosūti to vinam.
+
+**Man ir nepareiza balsu grupa.**
+Balsu grupu var mainīt tikai administrators. Lūdz vinam to izlabot.
+
+**Ka es varu uzzinat, kuras notis ir jaunas?**
+Krājumā darbi un izdevumi ir sakārtoti hronoloģiskā secībā. Skati arī pasākumus — tur bieži ir minēts, kādas notis būs vajadzīgas.
+
+**Vai es varu uzzinat, kas vēl neieradīsies uz meginajumu?**
+Jā, noklikškinat uz sava kora nosaukuma — sakumlapa parāda visu dalībnieku RSVP statusu.
+
+---
+
+_Rokasgramata atjaunināta: 20.02.2026_


### PR DESCRIPTION
## Summary
- Adds Latvian (lv) translations for singer, conductor, librarian, section-leader, and admin guide pages
- Wires all 5 into index.ts with titles, descriptions, and content entries
- All existing guide tests pass

## Test plan
- [x] 1413 tests passing, 0 type errors
- [x] Guide content test suite passes (18 tests)

Co-Authored-By: