### PR TITLE
fix: mock Paraglide runtime in vitest config (#291)

### DIFF
--- a/apps/vault/src/tests/mocks/paraglide-runtime.ts
+++ b/apps/vault/src/tests/mocks/paraglide-runtime.ts
@@ -1,0 +1,14 @@
+// Mock for $lib/paraglide/runtime — used when Paraglide build artifacts are absent
+// Provides the minimal exports consumed by production code under test
+
+export const baseLocale = 'en';
+export const locales = ['en', 'et', 'lv', 'uk'] as const;
+export const cookieName = 'PARAGLIDE_LOCALE';
+
+export function getLocale(): string {
+	return baseLocale;
+}
+
+export function setLocale(_locale: string): void {
+	// no-op in tests
+}

--- a/apps/vault/src/tests/mocks/paraglide-server.ts
+++ b/apps/vault/src/tests/mocks/paraglide-server.ts
@@ -1,0 +1,8 @@
+// Mock for $lib/paraglide/server — used when Paraglide build artifacts are absent
+
+export function paraglideMiddleware(
+	_request: Request,
+	callback: (args: { request: Request; locale: string }) => Response | Promise<Response>
+): Response | Promise<Response> {
+	return callback({ request: _request, locale: 'en' });
+}

--- a/apps/vault/vite.config.ts
+++ b/apps/vault/vite.config.ts
@@ -21,9 +21,17 @@ export default defineConfig(({ mode }) => ({
 				})
 			],
 	resolve: {
-		alias: {
-			'$lib': path.resolve(__dirname, './src/lib')
-		},
+		alias: [
+			// In test mode, mock Paraglide build artifacts (gitignored, may not exist in clean checkout).
+			// These MUST come before the $lib alias so they match first.
+			...(mode === 'test' ? [
+				{ find: '$lib/paraglide/runtime.js', replacement: path.resolve(__dirname, './src/tests/mocks/paraglide-runtime.ts') },
+				{ find: '$lib/paraglide/runtime', replacement: path.resolve(__dirname, './src/tests/mocks/paraglide-runtime.ts') },
+				{ find: '$lib/paraglide/server.js', replacement: path.resolve(__dirname, './src/tests/mocks/paraglide-server.ts') },
+				{ find: '$lib/paraglide/server', replacement: path.resolve(__dirname, './src/tests/mocks/paraglide-server.ts') },
+			] : []),
+			{ find: '$lib', replacement: path.resolve(__dirname, './src/lib') },
+		],
 		// Force client-side Svelte in test environment
 		conditions: mode === 'test' ? ['browser'] : undefined
 	},


### PR DESCRIPTION
## Summary
- Adds lightweight Paraglide mock files (`paraglide-runtime.ts`, `paraglide-server.ts`) under `src/tests/mocks/`
- Wires them as resolve aliases in `vite.config.ts` (test mode only, array format ordered before `$lib`)
- Fixes 4 test suites that fail in clean checkouts where Paraglide build artifacts don't exist

## Test plan
- [x] Removed `src/lib/paraglide/` entirely — 102/102 files, 1317/1317 tests pass
- [x] Restored `src/lib/paraglide/` — 102/102 files, 1317/1317 tests still pass
- [x] No production code changed — test infrastructure only