### PR TITLE
fix: sticky header unsticks too early on events/roster (#304)

### DIFF
--- a/apps/vault/src/lib/utils/sticky-header.spec.ts
+++ b/apps/vault/src/lib/utils/sticky-header.spec.ts
@@ -4,44 +4,37 @@ import { shouldHeaderStick } from './sticky-header';
 describe('shouldHeaderStick', () => {
 	const THRESHOLD = 100;
 
-	it('sticks when grid extends below the viewport', () => {
-		// gridBottom is beyond viewport
-		expect(shouldHeaderStick(1200, 800, THRESHOLD)).toBe(true);
+	it('sticks when grid extends well below the header', () => {
+		// gridBottom is far below the threshold (lots of content below header)
+		expect(shouldHeaderStick(1200, THRESHOLD)).toBe(true);
 	});
 
-	it('sticks when grid bottom is at the viewport bottom', () => {
-		// gridBottom === viewportHeight — no clearance yet
-		expect(shouldHeaderStick(800, 800, THRESHOLD)).toBe(true);
+	it('sticks when grid bottom is in the middle of the viewport', () => {
+		expect(shouldHeaderStick(500, THRESHOLD)).toBe(true);
 	});
 
-	it('sticks when grid bottom is just inside the viewport (under threshold)', () => {
-		// gridBottom is 50px above viewport bottom — not enough clearance
-		expect(shouldHeaderStick(750, 800, THRESHOLD)).toBe(true);
-	});
-
-	it('sticks at exactly 1px before threshold', () => {
-		// gridBottom is 99px above viewport bottom — still sticky
-		expect(shouldHeaderStick(701, 800, THRESHOLD)).toBe(true);
+	it('sticks when grid bottom is just above the threshold', () => {
+		// gridBottom is 101px from viewport top — still sticky
+		expect(shouldHeaderStick(101, THRESHOLD)).toBe(true);
 	});
 
 	it('unsticks at exactly the threshold boundary', () => {
-		// gridBottom is exactly 100px above viewport bottom
-		expect(shouldHeaderStick(700, 800, THRESHOLD)).toBe(false);
+		// gridBottom equals threshold — last row has reached the header
+		expect(shouldHeaderStick(100, THRESHOLD)).toBe(false);
 	});
 
-	it('unsticks when grid has cleared well past the threshold', () => {
-		// gridBottom is 300px above viewport bottom
-		expect(shouldHeaderStick(500, 800, THRESHOLD)).toBe(false);
+	it('unsticks when grid bottom is above the threshold', () => {
+		// gridBottom is 50px from viewport top — header should scroll away
+		expect(shouldHeaderStick(50, THRESHOLD)).toBe(false);
 	});
 
 	it('unsticks when grid is scrolled completely off-screen above', () => {
 		// gridBottom is negative (scrolled above viewport)
-		expect(shouldHeaderStick(-200, 800, THRESHOLD)).toBe(false);
+		expect(shouldHeaderStick(-200, THRESHOLD)).toBe(false);
 	});
 
 	it('works with different threshold values', () => {
-		// Custom threshold of 50px
-		expect(shouldHeaderStick(760, 800, 50)).toBe(true);
-		expect(shouldHeaderStick(750, 800, 50)).toBe(false);
+		expect(shouldHeaderStick(60, 50)).toBe(true);
+		expect(shouldHeaderStick(50, 50)).toBe(false);
 	});
 });

--- a/apps/vault/src/lib/utils/sticky-header.ts
+++ b/apps/vault/src/lib/utils/sticky-header.ts
@@ -1,20 +1,18 @@
 /**
  * Determines whether a sticky header should remain pinned.
  *
- * Returns true while grid content extends below the viewport (keeping the header
- * visible for context). Returns false once the last row has cleared the viewport
- * bottom by at least `threshold` pixels — at that point all data is visible and
- * the header can scroll away.
+ * Returns true while the grid body extends below the header position (top of
+ * viewport). Returns false once the last data row scrolls up to meet the
+ * header — at that point the header should scroll away with its table.
  *
  * @param gridBottom - Bottom edge of the grid container relative to the viewport
  *                     (from getBoundingClientRect().bottom)
- * @param viewportHeight - window.innerHeight
- * @param threshold - Required clearance in px before unsticking (default 100)
+ * @param threshold - Minimum distance from viewport top before unsticking.
+ *                    Should approximate the header's own height (default 100).
  */
 export function shouldHeaderStick(
 	gridBottom: number,
-	viewportHeight: number,
 	threshold: number
 ): boolean {
-	return gridBottom > viewportHeight - threshold;
+	return gridBottom > threshold;
 }

--- a/apps/vault/src/routes/events/roster/+page.svelte
+++ b/apps/vault/src/routes/events/roster/+page.svelte
@@ -62,7 +62,7 @@
 	function handleWindowScroll() {
 		if (!scrollContainer) return;
 		const gridBottom = scrollContainer.getBoundingClientRect().bottom;
-		headerShouldStick = shouldHeaderStick(gridBottom, window.innerHeight, UNSTICK_THRESHOLD);
+		headerShouldStick = shouldHeaderStick(gridBottom, UNSTICK_THRESHOLD);
 	}
 	// --- End smart unstick ---
 
@@ -375,7 +375,6 @@
 		<!-- Header band: sticky when content extends below viewport, static otherwise (#247) -->
 		<div
 			class="{headerShouldStick ? 'sticky top-0 z-40 shadow-md' : 'z-40'} rounded-t-lg border-t border-x border-gray-200 bg-white"
-			style="overflow: hidden;"
 			bind:this={headerScrollEl}
 		>
 					<div


### PR DESCRIPTION
## Summary

- **Fixes #304** — sticky header was detaching prematurely on events/roster page
- Fixed threshold calculation in `sticky-header.ts` utility
- Updated tests to match corrected behavior

## Test plan

- [x] Sticky header tests pass (`sticky-header.spec.ts`)
- [x] Full vault test suite passes