### PR TITLE
fix(#310): accept invite directly when user is already authenticated

### DIFF
--- a/apps/vault/src/routes/invite/accept/+page.server.ts
+++ b/apps/vault/src/routes/invite/accept/+page.server.ts
@@ -1,4 +1,5 @@
 import { redirect, error, type RequestEvent } from '@sveltejs/kit';
+import { acceptInvite } from '$lib/server/db/invites';
 
 export async function load({ url, platform, cookies }: RequestEvent) {
 	const db = platform?.env?.DB;
@@ -46,7 +47,26 @@ export async function load({ url, platform, cookies }: RequestEvent) {
 		throw redirect(302, cookies.get('member_id') ? '/' : '/login');
 	}
 
+	// If user is already authenticated, accept the invite directly (#310).
+	// This handles the cross-org case where SSO auto-auth resolves the member
+	// but the page would otherwise bounce through /login unnecessarily.
+	const memberId = cookies.get('member_id');
+	if (memberId) {
+		const member = await db
+			.prepare('SELECT email_id FROM members WHERE id = ?')
+			.bind(memberId)
+			.first<{ email_id: string | null }>();
+
+		if (member?.email_id) {
+			const result = await acceptInvite(db, token, member.email_id);
+			if (result.success) {
+				throw redirect(302, '/');
+			}
+			// If acceptance failed, fall through to login flow
+		}
+	}
+
 	// Redirect to login page with invite token
 	// Login page will set cookie and pass through whichever auth method user chooses
 	throw redirect(302, `/login?invite=${encodeURIComponent(token)}`);
-};
+}


### PR DESCRIPTION
## Summary
- `/invite/accept` page always redirected to `/login?invite=...` even when user was already authenticated
- In cross-org SSO flow, this caused a needless login roundtrip and confusing UX
- Fix: check `member_id` cookie, look up email, call `acceptInvite` directly, redirect to `/`

Fixes #310

## Test plan
- [x] 7 accept page tests pass
- [x] Full suite green (1508 tests)
- [ ] PO retest: authenticated user clicks cross-org invite link → lands on dashboard