### PR TITLE
fix(#313): remove dead invite roles code

### DIFF
--- a/apps/vault/src/lib/components/PendingInvitesCard.svelte
+++ b/apps/vault/src/lib/components/PendingInvitesCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Voice, Section, Role } from '$lib/types';
+	import type { Voice, Section } from '$lib/types';
 	import { VoiceBadge, SectionBadge } from '$lib/components/badges';
 	import { isExpired } from '$lib/utils/formatters';
 	import * as m from '$lib/paraglide/messages.js';
@@ -12,7 +12,6 @@
 		expiresAt: string;
 		invitedBy: string;
 		inviteLink: string;
-		roles: Role[];
 		voices?: Voice[];
 		sections?: Section[];
 	}
@@ -53,13 +52,6 @@
 									{m.invites_expired_badge()}
 								</span>
 							{/if}
-
-							<!-- Role badges -->
-							{#each invite.roles as role}
-								<span class="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
-									{role}
-								</span>
-							{/each}
 
 							<!-- Voice badges -->
 							{#if invite.voices && invite.voices.length > 0}

--- a/apps/vault/src/lib/server/db/invites.ts
+++ b/apps/vault/src/lib/server/db/invites.ts
@@ -13,7 +13,6 @@ export interface Invite {
 	token: string;
 	invited_by: string;
 	expires_at: string;
-	roles: Role[]; // Roles to assign upon acceptance (from junction table)
 	voices: Voice[]; // Inherited from roster member (display only)
 	sections: Section[]; // Inherited from roster member (display only)
 	created_at: string;
@@ -22,7 +21,6 @@ export interface Invite {
 export interface CreateInviteInput {
 	orgId: OrgId; // Required: which organization
 	rosterMemberId: string; // Required: which roster member to invite
-	roles: Role[]; // Roles to grant upon acceptance
 	invited_by: string;
 	emailHint?: string; // Optional: suggested email for Registry
 }
@@ -123,20 +121,15 @@ export async function createInvite(
 
 /**
  * Helper to load roster member, voices, and sections for an invite
- * Note: Remote DB doesn't have roles column or invite_roles table
  */
 async function loadInviteRelations(
 	db: D1Database,
-	inviteRow: Omit<Invite, 'roles' | 'voices' | 'sections' | 'roster_member_name'>
+	inviteRow: Omit<Invite, 'voices' | 'sections' | 'roster_member_name'>
 ): Promise<Invite> {
-	// Note: Remote DB doesn't have invite_roles junction table yet
-	// For now, default to empty roles array
-	const roles: Role[] = [];
-
 	// Get roster member to load name, voices, and sections
 	const { getMemberById } = await import('./members');
 	const rosterMember = await getMemberById(db, inviteRow.roster_member_id, inviteRow.orgId);
-	
+
 	// Handle missing roster member
 	const memberName = rosterMember?.name ?? 'Unknown Member';
 	const memberVoices = rosterMember?.voices ?? [];
@@ -145,7 +138,6 @@ async function loadInviteRelations(
 	return {
 		...inviteRow,
 		roster_member_name: memberName,
-		roles,
 		voices: memberVoices,
 		sections: memberSections
 	};
@@ -319,11 +311,6 @@ export async function acceptInvite(
 			invite.orgId
 		);
 		memberId = member.id;
-	}
-
-	// Transfer roles from invite to member
-	if (invite.roles.length > 0) {
-		await addMemberRoles(db, memberId, invite.roles, invite.invited_by, invite.orgId);
 	}
 
 	// Delete invite after successful acceptance (cleanup) — skip if already

--- a/apps/vault/src/lib/server/validation/schemas.ts
+++ b/apps/vault/src/lib/server/validation/schemas.ts
@@ -15,7 +15,6 @@ const eventTypeSchema = z.enum(EVENT_TYPES);
  */
 export const createInviteSchema = z.object({
 	rosterMemberId: z.string().min(1, 'Roster member ID is required'),
-	roles: z.array(roleSchema).optional().default([]),
 	emailHint: z.string().email().optional()
 });
 

--- a/apps/vault/src/routes/api/members/invite/+server.ts
+++ b/apps/vault/src/routes/api/members/invite/+server.ts
@@ -1,7 +1,7 @@
 // POST /api/members/invite - Create a new member invitation
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { getAuthenticatedMember, assertAdmin, isOwner } from '$lib/server/auth/middleware';
+import { getAuthenticatedMember, assertAdmin } from '$lib/server/auth/middleware';
 import { parseBody, createInviteSchema } from '$lib/server/validation/schemas';
 
 export const POST: RequestHandler = async ({ request, platform, cookies, locals }) => {
@@ -19,11 +19,6 @@ export const POST: RequestHandler = async ({ request, platform, cookies, locals 
 	// Validate request body with Zod
 	const body = await parseBody(request, createInviteSchema);
 
-	// Only owners can invite owners
-	if (body.roles.includes('owner') && !isOwner(member)) {
-		throw error(403, 'Only owners can invite other owners');
-	}
-
 	try {
 		// Import createInvite from DB operations
 		const { createInvite } = await import('$lib/server/db/invites');
@@ -32,7 +27,6 @@ export const POST: RequestHandler = async ({ request, platform, cookies, locals 
 		const invite = await createInvite(db, {
 			orgId,
 			rosterMemberId: body.rosterMemberId,
-			roles: body.roles,
 			emailHint: body.emailHint,
 			invited_by: member.id
 		});
@@ -45,7 +39,6 @@ export const POST: RequestHandler = async ({ request, platform, cookies, locals 
 				id: invite.id,
 				roster_member_id: invite.roster_member_id,
 				roster_member_name: invite.roster_member_name,
-				roles: invite.roles,
 				voices: invite.voices,
 				sections: invite.sections,
 				inviteLink,

--- a/apps/vault/src/routes/invite/+page.server.ts
+++ b/apps/vault/src/routes/invite/+page.server.ts
@@ -55,6 +55,7 @@ export const load: PageServerLoad = async ({ platform, cookies, url, locals }) =
 		rosterMember: rosterMember ? {
 			id: rosterMember.id,
 			name: rosterMember.name,
+			roles: rosterMember.roles,
 			voices: rosterMember.voices,
 			sections: rosterMember.sections
 		} : null

--- a/apps/vault/src/routes/invite/+page.svelte
+++ b/apps/vault/src/routes/invite/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { ASSIGNABLE_ROLES, type Role } from '$lib/types';
 	import { toast } from '$lib/stores/toast';
 	import { VoiceBadge, SectionBadge } from '$lib/components/badges';
 	import InviteLinkCard from '$lib/components/InviteLinkCard.svelte';
@@ -13,20 +12,9 @@
 	let rosterMember = $derived(data.rosterMember);
 
 	// Form state
-	let roles = $state<Set<Role>>(new Set());
 	let isSubmitting = $state(false);
 	let success = $state('');
 	let inviteLink = $state('');
-
-	function toggleRole(role: Role) {
-		const newRoles = new Set(roles);
-		if (newRoles.has(role)) {
-			newRoles.delete(role);
-		} else {
-			newRoles.add(role);
-		}
-		roles = newRoles;
-	}
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
@@ -47,8 +35,7 @@
 					'Content-Type': 'application/json'
 				},
 				body: JSON.stringify({
-					rosterMemberId: rosterMember.id,
-					roles: Array.from(roles)
+					rosterMemberId: rosterMember.id
 				})
 			});
 
@@ -60,7 +47,6 @@
 			const result = (await response.json()) as { inviteLink: string };
 			inviteLink = result.inviteLink;
 			success = m.invite_success_message({ name: rosterMember.name });
-			roles = new Set();
 		} catch (err) {
 			toast.error(err instanceof Error ? err.message : m.invite_error_send_failed());
 		} finally {
@@ -155,43 +141,22 @@
 				</div>
 
 				<form onsubmit={handleSubmit} class="space-y-4">
-					<fieldset>
-						<legend class="mb-2 block text-sm font-medium text-gray-700">
+					<div>
+						<p class="mb-2 block text-sm font-medium text-gray-700">
 							{m.invite_roles_legend()}
-						</legend>
-						<div class="space-y-2">
-							{#each ASSIGNABLE_ROLES as role}
-								{#if role !== 'owner' || data.isOwner}
-									<label class="flex items-center gap-2">
-										<input
-											type="checkbox"
-											checked={roles.has(role)}
-											onchange={() => toggleRole(role)}
-											disabled={isSubmitting}
-											class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-										/>
-										<span class="text-sm">
-											<span class="font-medium">{m[`roles_${role}`]()}</span>
-											{#if role === 'owner'}
-												- {m.invite_role_owner_desc()}
-											{:else if role === 'admin'}
-												- {m.invite_role_admin_desc()}
-											{:else if role === 'librarian'}
-												- {m.invite_role_librarian_desc()}
-											{:else if role === 'conductor'}
-												- {m.invite_role_conductor_desc()}
-											{:else if role === 'section_leader'}
-												- {m.invite_role_section_leader_desc()}
-											{/if}
-										</span>
-									</label>
-								{/if}
-							{/each}
-						</div>
-						<p class="mt-2 text-sm text-gray-500">
-							{m.invite_roles_help()}
 						</p>
-					</fieldset>
+						<div class="flex flex-wrap gap-2">
+							{#if rosterMember.roles.length > 0}
+								{#each rosterMember.roles as role}
+									<span class="inline-flex items-center rounded px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-800">
+										{m[`roles_${role}`]()}
+									</span>
+								{/each}
+							{:else}
+								<span class="text-sm text-gray-500">{m.member_no_roles()}</span>
+							{/if}
+						</div>
+					</div>
 
 					<button
 						type="submit"

--- a/apps/vault/src/tests/lib/server/db/invites-roster.spec.ts
+++ b/apps/vault/src/tests/lib/server/db/invites-roster.spec.ts
@@ -367,14 +367,11 @@ describe('createInvite (roster-linked)', () => {
 		const invite = await createInvite(mockDb, {
 			orgId: TEST_ORG_ID,
 			rosterMemberId: rosterId,
-			roles: ['librarian'],
 			invited_by: adminId
 		});
 
 		expect(invite.roster_member_id).toBe(rosterId);
 		expect(invite.roster_member_name).toBe('John Doe');
-		// Note: Production DB doesn't have roles column - roles would be stored in invite_roles junction table
-		expect(invite.roles).toEqual([]);
 		// Note: voices/sections come from roster member (tested in members.spec.ts)
 	});
 
@@ -389,7 +386,6 @@ describe('createInvite (roster-linked)', () => {
 			createInvite(mockDb, {
 				orgId: TEST_ORG_ID,
 				rosterMemberId: rosterId,
-				roles: [],
 				invited_by: adminId
 			})
 		).rejects.toThrow('already registered');
@@ -400,7 +396,6 @@ describe('createInvite (roster-linked)', () => {
 		await createInvite(mockDb, {
 			orgId: TEST_ORG_ID,
 			rosterMemberId: rosterId,
-			roles: [],
 			invited_by: adminId
 		});
 
@@ -409,7 +404,6 @@ describe('createInvite (roster-linked)', () => {
 			createInvite(mockDb, {
 				orgId: TEST_ORG_ID,
 				rosterMemberId: rosterId,
-				roles: [],
 				invited_by: adminId
 			})
 		).rejects.toThrow('already has a pending invitation');
@@ -446,7 +440,6 @@ describe('acceptInvite (roster upgrade)', () => {
 		const invite = await createInvite(mockDb, {
 			orgId: TEST_ORG_ID,
 			rosterMemberId: rosterId,
-			roles: ['librarian', 'conductor'],
 			invited_by: adminId
 		});
 		inviteToken = invite.token;

--- a/apps/vault/src/tests/lib/server/validation/schemas.spec.ts
+++ b/apps/vault/src/tests/lib/server/validation/schemas.spec.ts
@@ -14,39 +14,21 @@ import {
 describe('createInviteSchema', () => {
 	it('validates a valid invite with roster member ID', () => {
 		const result = createInviteSchema.safeParse({
-			rosterMemberId: 'member123',
-			roles: ['admin', 'librarian']
+			rosterMemberId: 'member123'
 		});
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data.rosterMemberId).toBe('member123');
-			expect(result.data.roles).toEqual(['admin', 'librarian']);
 		}
 	});
 
 	it('requires rosterMemberId', () => {
-		const result = createInviteSchema.safeParse({ roles: [] });
+		const result = createInviteSchema.safeParse({});
 		expect(result.success).toBe(false);
 	});
 
 	it('rejects empty rosterMemberId', () => {
-		const result = createInviteSchema.safeParse({ rosterMemberId: '', roles: [] });
-		expect(result.success).toBe(false);
-	});
-
-	it('defaults roles to empty array', () => {
-		const result = createInviteSchema.safeParse({ rosterMemberId: 'member123' });
-		expect(result.success).toBe(true);
-		if (result.success) {
-			expect(result.data.roles).toEqual([]);
-		}
-	});
-
-	it('rejects invalid role', () => {
-		const result = createInviteSchema.safeParse({
-			rosterMemberId: 'member123',
-			roles: ['invalid_role']
-		});
+		const result = createInviteSchema.safeParse({ rosterMemberId: '' });
 		expect(result.success).toBe(false);
 	});
 });
@@ -82,13 +64,12 @@ describe('parseBody', () => {
 	it('parses valid JSON and validates', async () => {
 		const request = new Request('http://test', {
 			method: 'POST',
-			body: JSON.stringify({ rosterMemberId: 'member123', roles: ['admin'] }),
+			body: JSON.stringify({ rosterMemberId: 'member123' }),
 			headers: { 'Content-Type': 'application/json' }
 		});
 
 		const result = await parseBody(request, createInviteSchema);
 		expect(result.rosterMemberId).toBe('member123');
-		expect(result.roles).toEqual(['admin']);
 	});
 
 	it('throws on invalid JSON', async () => {

--- a/apps/vault/src/tests/routes/api/members/invite.spec.ts
+++ b/apps/vault/src/tests/routes/api/members/invite.spec.ts
@@ -22,8 +22,7 @@ vi.mock('@sveltejs/kit', async () => {
 // Mock middleware
 vi.mock('$lib/server/auth/middleware', () => ({
 	getAuthenticatedMember: vi.fn(),
-	assertAdmin: vi.fn(),
-	isOwner: vi.fn()
+	assertAdmin: vi.fn()
 }));
 
 // Mock validation schemas
@@ -32,7 +31,7 @@ vi.mock('$lib/server/validation/schemas', () => ({
 	createInviteSchema: {}
 }));
 
-import { getAuthenticatedMember, assertAdmin, isOwner } from '$lib/server/auth/middleware';
+import { getAuthenticatedMember, assertAdmin } from '$lib/server/auth/middleware';
 import { parseBody } from '$lib/server/validation/schemas';
 
 function createMockRequest(body: any) {
@@ -72,7 +71,6 @@ describe('POST /api/members/invite', () => {
 			id: 'invite-789',
 			name: 'Multi Voice Singer',
 			token: 'token-multi',
-			roles: [],
 			voices: [
 				{ id: 'voice-tenor', name: 'Tenor', abbreviation: 'T' },
 				{ id: 'voice-baritone', name: 'Baritone', abbreviation: 'Bar' }
@@ -85,12 +83,9 @@ describe('POST /api/members/invite', () => {
 
 		vi.mocked(getAuthenticatedMember).mockResolvedValue(mockAdmin as any);
 		vi.mocked(assertAdmin).mockImplementation(() => {});
-		vi.mocked(isOwner).mockReturnValue(false);
 		vi.mocked(parseBody).mockResolvedValue({
-			name: 'Multi Voice Singer',
-			roles: [],
-			voiceIds: ['voice-tenor', 'voice-baritone'],
-			sectionIds: ['section-tenor-1', 'section-tenor-2']
+			rosterMemberId: 'roster-1',
+			emailHint: undefined
 		});
 
 		// Mock createInvite dynamically
@@ -101,10 +96,7 @@ describe('POST /api/members/invite', () => {
 
 		const response = await POST({
 			request: createMockRequest({
-				name: 'Multi Voice Singer',
-				roles: [],
-				voiceIds: ['voice-tenor', 'voice-baritone'],
-				sectionIds: ['section-tenor-1', 'section-tenor-2']
+				rosterMemberId: 'roster-1'
 			}),
 			platform: { env: { DB: {} } },
 			cookies: createMockCookies(),
@@ -112,7 +104,7 @@ describe('POST /api/members/invite', () => {
 		} as any);
 
 		const json = (await response.json()) as any;
-		
+
 		expect(json.voices).toHaveLength(2);
 		expect(json.sections).toHaveLength(2);
 		expect(json.voices[0].name).toBe('Tenor');
@@ -141,29 +133,4 @@ describe('POST /api/members/invite', () => {
 		).rejects.toThrow('Insufficient permissions');
 	});
 
-	it('blocks non-owners from inviting owners', async () => {
-		const mockAdmin = { id: 'admin-1', email: 'admin@test.com', roles: ['admin'] };
-		
-		vi.mocked(getAuthenticatedMember).mockResolvedValue(mockAdmin as any);
-		vi.mocked(assertAdmin).mockImplementation(() => {});
-		vi.mocked(isOwner).mockReturnValue(false);
-		vi.mocked(parseBody).mockResolvedValue({
-			name: 'Would-be Owner',
-			roles: ['owner'],
-			voiceIds: [],
-			sectionIds: []
-		});
-
-		await expect(
-			POST({
-				request: createMockRequest({
-					name: 'Would-be Owner',
-					roles: ['owner']
-				}),
-				platform: { env: { DB: {} } },
-				cookies: createMockCookies(),
-				locals: { org: mockOrg }
-			} as any)
-		).rejects.toThrow('Only owners can invite other owners');
-	});
 });


### PR DESCRIPTION
## Summary
- Remove dead invite roles code path end-to-end: roles were accepted by the API but never persisted (no `invite_roles` junction table on production)
- Remove `roles` from `Invite` interface, `CreateInviteInput`, Zod schema, API endpoint, `loadInviteRelations`, and dead `acceptInvite` branch
- Remove role picker UI from invite form, remove roles from `PendingInvitesCard`
- Update tests to match new behavior (remove roles assertions and payloads)
- Cross-org `member_roles` transfer in `acceptInvite` (live code) is unchanged

Closes #313

## Test plan
- [x] All 1346 vault tests pass
- [x] Invite creation works without roles in request body
- [x] Cross-org invite acceptance still transfers member_roles from roster slot
- [ ] Follow-up: Comenius to clean dead i18n keys (`m.invite_role_*_desc()`, `m.invite_roles_help()`)