### PR TITLE
fix: invite form broken by deleted i18n key

### DIFF
--- a/apps/vault/src/routes/invite/+page.svelte
+++ b/apps/vault/src/routes/invite/+page.svelte
@@ -143,7 +143,7 @@
 				<form onsubmit={handleSubmit} class="space-y-4">
 					<div>
 						<p class="mb-2 block text-sm font-medium text-gray-700">
-							{m.invite_roles_legend()}
+							{m.invite_assigned_roles()}
 						</p>
 						<div class="flex flex-wrap gap-2">
 							{#if rosterMember.roles.length > 0}


### PR DESCRIPTION
## Summary
- PR #318 removed `invite_roles_legend` from all locale files but the template in `+page.svelte` still referenced `m.invite_roles_legend()`
- Runtime error prevented form submit handler from binding, causing default GET behavior instead of POST
- Replace with `m.invite_assigned_roles()` which exists in all 4 locales

## Test plan
- [x] Invite form renders without runtime error
- [x] Send button POSTs to `/api/members/invite`