### PR TITLE
chore: commit straggling code from #310, #315, #316

### DIFF
--- a/apps/vault/src/lib/server/db/queries/members.spec.ts
+++ b/apps/vault/src/lib/server/db/queries/members.spec.ts
@@ -47,15 +47,17 @@ function createMockDB() {
 
 							// Member voices query
 							if (sql.includes('member_voices mv') && sql.includes('mv.member_id = ?')) {
-								const [memberId] = params;
+								const [memberId, orgId] = params;
 								const memberVcs = mockState.memberVoices.get(memberId) || [];
-								const results = memberVcs.map((mv) => {
-									const voice = mockState.voices.get(mv.voice_id);
-									return {
-										...voice,
-										is_primary: mv.is_primary
-									};
-								});
+								const results = memberVcs
+									.map((mv) => {
+										const voice = mockState.voices.get(mv.voice_id);
+										return {
+											...voice,
+											is_primary: mv.is_primary
+										};
+									})
+									.filter((v) => !orgId || v.org_id === orgId);
 								return { results };
 							}
 
@@ -208,7 +210,7 @@ describe('Member Query Utilities', () => {
 
 	describe('queryMemberVoices', () => {
 		it('should return empty array when member has no voices', async () => {
-			const result = await queryMemberVoices(mockDb, 'mem_1');
+			const result = await queryMemberVoices(mockDb, 'mem_1', TEST_ORG_ID);
 
 			expect(result).toEqual([]);
 		});
@@ -221,14 +223,15 @@ describe('Member Query Utilities', () => {
 				category: 'vocal',
 				range_group: 'high',
 				display_order: 1,
-				is_active: 1
+				is_active: 1,
+				org_id: 'org_test_001'
 			});
 
 			mockDb.__mockState.memberVoices.set('mem_1', [
 				{ voice_id: 'voice_1', is_primary: 1 }
 			]);
 
-			const result = await queryMemberVoices(mockDb, 'mem_1');
+			const result = await queryMemberVoices(mockDb, 'mem_1', TEST_ORG_ID);
 
 			expect(result).toHaveLength(1);
 			expect(result[0]).toEqual({
@@ -250,7 +253,8 @@ describe('Member Query Utilities', () => {
 				category: 'vocal',
 				range_group: 'high',
 				display_order: 1,
-				is_active: 1
+				is_active: 1,
+				org_id: 'org_test_001'
 			});
 			mockDb.__mockState.voices.set('voice_2', {
 				id: 'voice_2',
@@ -259,7 +263,8 @@ describe('Member Query Utilities', () => {
 				category: 'vocal',
 				range_group: 'mid',
 				display_order: 2,
-				is_active: 1
+				is_active: 1,
+				org_id: 'org_test_001'
 			});
 
 			mockDb.__mockState.memberVoices.set('mem_1', [
@@ -267,7 +272,7 @@ describe('Member Query Utilities', () => {
 				{ voice_id: 'voice_1', is_primary: 0 }  // Soprano
 			]);
 
-			const result = await queryMemberVoices(mockDb, 'mem_1');
+			const result = await queryMemberVoices(mockDb, 'mem_1', TEST_ORG_ID);
 
 			expect(result).toHaveLength(2);
 			expect(result[0].id).toBe('voice_2');
@@ -282,16 +287,53 @@ describe('Member Query Utilities', () => {
 				category: 'instrumental',
 				range_group: null,
 				display_order: 10,
-				is_active: 1
+				is_active: 1,
+				org_id: 'org_test_001'
 			});
 
 			mockDb.__mockState.memberVoices.set('mem_1', [
 				{ voice_id: 'voice_1', is_primary: 1 }
 			]);
 
-			const result = await queryMemberVoices(mockDb, 'mem_1');
+			const result = await queryMemberVoices(mockDb, 'mem_1', TEST_ORG_ID);
 
 			expect(result[0].rangeGroup).toBeNull();
+		});
+
+		it('should exclude voices that belong to a different org', async () => {
+			const OTHER_ORG_ID = createOrgId('org_other_001');
+
+			mockDb.__mockState.voices.set('voice_own', {
+				id: 'voice_own',
+				name: 'Soprano',
+				abbreviation: 'S',
+				category: 'vocal',
+				range_group: 'high',
+				display_order: 1,
+				is_active: 1,
+				org_id: 'org_test_001'  // belongs to TEST_ORG_ID
+			});
+			mockDb.__mockState.voices.set('voice_foreign', {
+				id: 'voice_foreign',
+				name: 'Tenor',
+				abbreviation: 'T',
+				category: 'vocal',
+				range_group: 'low',
+				display_order: 2,
+				is_active: 1,
+				org_id: 'org_other_001' // belongs to OTHER_ORG_ID
+			});
+
+			mockDb.__mockState.memberVoices.set('mem_1', [
+				{ voice_id: 'voice_own', is_primary: 1 },
+				{ voice_id: 'voice_foreign', is_primary: 0 }
+			]);
+
+			const result = await queryMemberVoices(mockDb, 'mem_1', TEST_ORG_ID);
+
+			// Only the voice belonging to TEST_ORG_ID should be returned
+			expect(result).toHaveLength(1);
+			expect(result[0].id).toBe('voice_own');
 		});
 	});
 

--- a/apps/vault/src/routes/invite/accept/accept-authenticated.spec.ts
+++ b/apps/vault/src/routes/invite/accept/accept-authenticated.spec.ts
@@ -1,0 +1,272 @@
+// TDD: Authenticated user fast-path for /invite/accept (#310)
+//
+// Root cause: the page unconditionally redirected authenticated users to
+// /login?invite=... even when they already had a session. In the cross-org
+// case, if the pending_invite cookie was lost in the redirect chain, the user
+// ended up in a /login → /invite/accept → /login loop.
+//
+// Fix (65b7766): if member_id cookie present, look up member email and call
+// acceptInvite directly, redirecting to / on success.
+//
+// Tests here are RED against the unfixed code path (always redirected to login)
+// and GREEN with the fix applied.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock SvelteKit — redirect and error both throw, matching real behaviour
+vi.mock('@sveltejs/kit', () => ({
+	redirect: (status: number, location: string) => {
+		const err = new Error(`Redirect to ${location}`);
+		(err as any).status = status;
+		(err as any).location = location;
+		throw err;
+	},
+	error: (status: number, message: string) => {
+		const err = new Error(message);
+		(err as any).status = status;
+		throw err;
+	}
+}));
+
+// Mock acceptInvite so tests are isolated from the DB layer
+vi.mock('$lib/server/db/invites', () => ({
+	acceptInvite: vi.fn()
+}));
+
+import { acceptInvite } from '$lib/server/db/invites';
+
+const FUTURE = new Date(Date.now() + 86_400_000).toISOString();
+const VALID_TOKEN = 'invite_tok_valid';
+const ROSTER_MEMBER_ID = 'roster_b_001';
+const SESSION_MEMBER_ID = 'alice_001';
+const ALICE_EMAIL = 'alice@chorus.org';
+
+/**
+ * Build a mock D1Database that answers the three SELECT queries the page
+ * may issue:
+ *   1. SELECT id, roster_member_id, expires_at FROM invites WHERE token = ?
+ *   2. SELECT email_id FROM members WHERE id = ?  (roster member)
+ *   3. SELECT email_id FROM members WHERE id = ?  (session member)
+ *
+ * The mock dispatches by SQL snippet + bound params so call order doesn't matter.
+ */
+function createMockDb(opts: {
+	inviteRow: { id: string; roster_member_id: string; expires_at: string } | null;
+	rosterEmailId: string | null;
+	sessionMemberEmailId: string | null;
+}) {
+	return {
+		prepare: (sql: string) => ({
+			bind: (...params: unknown[]) => ({
+				first: vi.fn(async () => {
+					// Invite lookup
+					if (sql.includes('FROM invites')) {
+						return opts.inviteRow;
+					}
+					// Member email lookup — dispatch by bound id
+					if (sql.includes('FROM members WHERE id = ?')) {
+						const id = params[0] as string;
+						if (id === ROSTER_MEMBER_ID) return { email_id: opts.rosterEmailId };
+						if (id === SESSION_MEMBER_ID) return { email_id: opts.sessionMemberEmailId };
+					}
+					return null;
+				})
+			})
+		})
+	} as unknown as D1Database;
+}
+
+function createEvent(opts: {
+	memberId?: string | null;
+	db?: D1Database;
+}) {
+	return {
+		url: new URL(`https://crede.polyphony.uk/invite/accept?token=${VALID_TOKEN}`),
+		platform: { env: { DB: opts.db } },
+		cookies: {
+			get: vi.fn((name: string) => (name === 'member_id' ? (opts.memberId ?? null) : null))
+		}
+	} as any;
+}
+
+// ─── AC1: Authenticated user → fast-path redirect to / ───────────────────────
+
+describe('invite/accept — authenticated user fast-path (#310)', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+	});
+
+	it('redirects authenticated user to / after successful acceptInvite (not to /login)', async () => {
+		vi.mocked(acceptInvite).mockResolvedValue({ success: true, memberId: SESSION_MEMBER_ID });
+
+		const db = createMockDb({
+			inviteRow: { id: 'inv_1', roster_member_id: ROSTER_MEMBER_ID, expires_at: FUTURE },
+			rosterEmailId: null,           // roster slot has no email yet
+			sessionMemberEmailId: ALICE_EMAIL // authenticated user has email
+		});
+
+		const { load } = await import('./+page.server');
+
+		try {
+			await load(createEvent({ memberId: SESSION_MEMBER_ID, db }));
+			expect.fail('Expected redirect');
+		} catch (err: any) {
+			// RED against unfixed code: unfixed always redirects to /login?invite=...
+			expect(err.status).toBe(302);
+			expect(err.location).toBe('/');
+		}
+	});
+
+	it('calls acceptInvite with the session member email, not the roster slot id', async () => {
+		vi.mocked(acceptInvite).mockResolvedValue({ success: true, memberId: SESSION_MEMBER_ID });
+
+		const db = createMockDb({
+			inviteRow: { id: 'inv_1', roster_member_id: ROSTER_MEMBER_ID, expires_at: FUTURE },
+			rosterEmailId: null,
+			sessionMemberEmailId: ALICE_EMAIL
+		});
+
+		const { load } = await import('./+page.server');
+
+		try {
+			await load(createEvent({ memberId: SESSION_MEMBER_ID, db }));
+		} catch {
+			// expected redirect
+		}
+
+		// RED: unfixed code never calls acceptInvite — it just redirects to login.
+		expect(acceptInvite).toHaveBeenCalledOnce();
+		expect(acceptInvite).toHaveBeenCalledWith(db, VALID_TOKEN, ALICE_EMAIL);
+	});
+});
+
+// ─── AC2: Cross-org case — authenticated org-A user accepts org-B invite ─────
+
+describe('invite/accept — cross-org authenticated acceptance (#310)', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+	});
+
+	it('completes cross-org accept without a /login roundtrip', async () => {
+		// Scenario: alice is registered in org A. Org B created a roster slot and
+		// sent her an invite. She opens the invite link while already logged in
+		// to org B via SSO. The page should resolve via acceptInvite directly.
+		vi.mocked(acceptInvite).mockResolvedValue({ success: true, memberId: SESSION_MEMBER_ID });
+
+		const db = createMockDb({
+			inviteRow: { id: 'inv_cross', roster_member_id: ROSTER_MEMBER_ID, expires_at: FUTURE },
+			rosterEmailId: null,             // org-B roster slot — no email
+			sessionMemberEmailId: ALICE_EMAIL // alice is already authenticated (from org A SSO)
+		});
+
+		const { load } = await import('./+page.server');
+
+		try {
+			await load(createEvent({ memberId: SESSION_MEMBER_ID, db }));
+			expect.fail('Expected redirect');
+		} catch (err: any) {
+			// RED: unfixed code redirects cross-org authenticated users to /login,
+			// where the pending_invite cookie can be lost, creating a loop.
+			expect(err.status).toBe(302);
+			expect(err.location).toBe('/');
+		}
+	});
+
+	it('does not redirect cross-org authenticated user to /login', async () => {
+		vi.mocked(acceptInvite).mockResolvedValue({ success: true, memberId: SESSION_MEMBER_ID });
+
+		const db = createMockDb({
+			inviteRow: { id: 'inv_cross', roster_member_id: ROSTER_MEMBER_ID, expires_at: FUTURE },
+			rosterEmailId: null,
+			sessionMemberEmailId: ALICE_EMAIL
+		});
+
+		const { load } = await import('./+page.server');
+
+		try {
+			await load(createEvent({ memberId: SESSION_MEMBER_ID, db }));
+			expect.fail('Expected redirect');
+		} catch (err: any) {
+			expect(err.location).not.toContain('/login');
+		}
+	});
+});
+
+// ─── AC3: acceptInvite failure — fall through to login flow ──────────────────
+
+describe('invite/accept — authenticated but acceptInvite fails (#310)', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+	});
+
+	it('falls through to /login?invite=token when acceptInvite returns failure', async () => {
+		vi.mocked(acceptInvite).mockResolvedValue({ success: false, error: 'Invite already used' });
+
+		const db = createMockDb({
+			inviteRow: { id: 'inv_used', roster_member_id: ROSTER_MEMBER_ID, expires_at: FUTURE },
+			rosterEmailId: null,
+			sessionMemberEmailId: ALICE_EMAIL
+		});
+
+		const { load } = await import('./+page.server');
+
+		try {
+			await load(createEvent({ memberId: SESSION_MEMBER_ID, db }));
+			expect.fail('Expected redirect');
+		} catch (err: any) {
+			expect(err.status).toBe(302);
+			expect(err.location).toBe(`/login?invite=${encodeURIComponent(VALID_TOKEN)}`);
+		}
+	});
+});
+
+// ─── Guard: Unauthenticated user still uses the login flow (no regression) ───
+
+describe('invite/accept — unauthenticated user unchanged (#310 guard)', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+	});
+
+	it('redirects unauthenticated user to /login?invite=token as before', async () => {
+		const db = createMockDb({
+			inviteRow: { id: 'inv_1', roster_member_id: ROSTER_MEMBER_ID, expires_at: FUTURE },
+			rosterEmailId: null,
+			sessionMemberEmailId: null // no session member
+		});
+
+		const { load } = await import('./+page.server');
+
+		try {
+			await load(createEvent({ memberId: null, db }));
+			expect.fail('Expected redirect');
+		} catch (err: any) {
+			expect(err.status).toBe(302);
+			expect(err.location).toBe(`/login?invite=${encodeURIComponent(VALID_TOKEN)}`);
+		}
+
+		// acceptInvite must NOT be called for unauthenticated requests
+		expect(acceptInvite).not.toHaveBeenCalled();
+	});
+
+	it('does not call acceptInvite when member_id cookie is absent', async () => {
+		const db = createMockDb({
+			inviteRow: { id: 'inv_1', roster_member_id: ROSTER_MEMBER_ID, expires_at: FUTURE },
+			rosterEmailId: null,
+			sessionMemberEmailId: null
+		});
+
+		const { load } = await import('./+page.server');
+
+		try {
+			await load(createEvent({ memberId: null, db }));
+		} catch {
+			// expected redirect
+		}
+
+		expect(acceptInvite).not.toHaveBeenCalled();
+	});
+});

--- a/apps/vault/src/routes/members/+page.server.ts
+++ b/apps/vault/src/routes/members/+page.server.ts
@@ -33,7 +33,6 @@ function formatInvites(pendingInvites: Awaited<ReturnType<typeof getPendingInvit
 		id: inv.id,
 		rosterId: inv.roster_member_id,
 		name: inv.roster_member_name,
-		roles: inv.roles,
 		voices: inv.voices,
 		sections: inv.sections,
 		createdAt: inv.created_at,

--- a/apps/vault/src/routes/members/+page.svelte
+++ b/apps/vault/src/routes/members/+page.svelte
@@ -86,14 +86,13 @@
 				roster_member_name: string;
 				expires_at: string;
 				created_at: string;
-				roles: typeof invites[0]['roles'];
 				voices: typeof invites[0]['voices'];
 				sections: typeof invites[0]['sections'];
 			};
-			
+
 			// Find original to preserve inviteLink and invitedBy
 			const original = invites.find((inv) => inv.id === inviteId);
-			
+
 			const renewedInvite: Invite = {
 				id: rawInvite.id,
 				rosterId: rawInvite.roster_member_id,
@@ -101,7 +100,6 @@
 				expiresAt: rawInvite.expires_at,
 				invitedBy: original?.invitedBy ?? m.members_invited_by_unknown(),
 				inviteLink: original?.inviteLink ?? '',
-				roles: rawInvite.roles,
 				voices: rawInvite.voices,
 				sections: rawInvite.sections
 			};


### PR DESCRIPTION
## Summary
- `members.spec.ts`: org-scoped voice mock fix from #316
- `+page.server.ts`, `+page.svelte`: remove stale `inv.roles` references from #315
- `accept-authenticated.spec.ts`: new test file for #310 invite accept flow

These changes were left uncommitted on main after their respective PRs.

## Test plan
- [x] All changes are from previously reviewed PRs