### PR TITLE
fix: resolve 20 type errors in test files

### DIFF
--- a/apps/vault/src/routes/api/auth/logout/logout.spec.ts
+++ b/apps/vault/src/routes/api/auth/logout/logout.spec.ts
@@ -29,7 +29,7 @@ function createMockEvent(
         cookieJar.delete(name);
       },
     },
-  } as Parameters<typeof GET>[0];
+  } as unknown as Parameters<typeof GET>[0];
 
   return { event, deletedCookies };
 }

--- a/apps/vault/src/tests/lib/server/db/org-id-not-null.spec.ts
+++ b/apps/vault/src/tests/lib/server/db/org-id-not-null.spec.ts
@@ -269,7 +269,6 @@ describe("createInvite — must reject missing orgId (#251)", () => {
       createInvite(db, {
         orgId: null as unknown as OrgId,
         rosterMemberId: "member_1",
-        roles: [],
         invited_by: "member_admin",
       }),
     ).rejects.toThrow();
@@ -282,7 +281,6 @@ describe("createInvite — must reject missing orgId (#251)", () => {
       createInvite(db, {
         orgId: "" as OrgId,
         rosterMemberId: "member_1",
-        roles: [],
         invited_by: "member_admin",
       }),
     ).rejects.toThrow();

--- a/apps/vault/src/tests/routes/api/auth/login.spec.ts
+++ b/apps/vault/src/tests/routes/api/auth/login.spec.ts
@@ -160,7 +160,7 @@ describe("GET /api/auth/login — return_to open-redirect guard", () => {
     it("always redirects (302) to registry regardless of return_to validity", async () => {
       const event = createMockEvent("https://evil.com");
 
-      const err: any = await GET(event as any).catch((e) => e);
+      const err: any = await Promise.resolve(GET(event as any)).catch((e: any) => e);
 
       expect(err.status).toBe(302);
       expect(err.location).toContain("registry.example.com");
@@ -169,7 +169,7 @@ describe("GET /api/auth/login — return_to open-redirect guard", () => {
     it("redirect URL includes vault_id and callback params", async () => {
       const event = createMockEvent("/dashboard");
 
-      const err: any = await GET(event as any).catch((e) => e);
+      const err: any = await Promise.resolve(GET(event as any)).catch((e: any) => e);
 
       expect(err.location).toContain("vault_id=test-vault-id");
       expect(err.location).toContain("callback=");

--- a/apps/vault/src/tests/routes/api/seasons.spec.ts
+++ b/apps/vault/src/tests/routes/api/seasons.spec.ts
@@ -124,7 +124,7 @@ describe("GET /api/seasons", () => {
     const response = await GET_SEASONS(event);
 
     expect(response.status).toBe(200);
-    const data = await response.json();
+    const data = (await response.json()) as any[];
     expect(Array.isArray(data)).toBe(true);
     expect(data).toHaveLength(1);
     expect(data[0].name).toBe("Fall 2026");
@@ -136,7 +136,7 @@ describe("GET /api/seasons", () => {
 
     const response = await GET_SEASONS(event);
 
-    const data = await response.json();
+    const data = (await response.json()) as any[];
     expect(data).toEqual([]);
   });
 
@@ -150,7 +150,7 @@ describe("GET /api/seasons", () => {
 
     expect(mockGetSeasonByDate).toHaveBeenCalled();
     expect(mockGetAllSeasons).not.toHaveBeenCalled();
-    const data = await response.json();
+    const data = (await response.json()) as Record<string, unknown>;
     expect(data.name).toBe("Fall 2026");
   });
 
@@ -226,7 +226,7 @@ describe("POST /api/seasons", () => {
     const response = await POST(event);
 
     expect(response.status).toBe(400);
-    const data = await response.json();
+    const data = (await response.json()) as Record<string, unknown>;
     expect(data.error).toContain("Name");
   });
 
@@ -256,7 +256,7 @@ describe("POST /api/seasons", () => {
     const response = await POST(event);
 
     expect(response.status).toBe(400);
-    const data = await response.json();
+    const data = (await response.json()) as Record<string, unknown>;
     expect(data.error).toContain("date");
   });
 
@@ -272,7 +272,7 @@ describe("POST /api/seasons", () => {
     const response = await POST(event);
 
     expect(response.status).toBe(400);
-    const data = await response.json();
+    const data = (await response.json()) as Record<string, unknown>;
     expect(data.error).toContain("YYYY-MM-DD");
   });
 
@@ -325,7 +325,7 @@ describe("GET /api/seasons/[id]", () => {
     const response = await GET_SEASON(event);
 
     expect(response.status).toBe(200);
-    const data = await response.json();
+    const data = (await response.json()) as Record<string, unknown>;
     expect(data.id).toBe("season-1");
     expect(data.name).toBe("Fall 2026");
   });
@@ -351,9 +351,9 @@ describe("GET /api/seasons/[id]", () => {
     const response = await GET_SEASON(event);
 
     expect(mockGetSeasonEvents).toHaveBeenCalled();
-    const data = await response.json();
+    const data = (await response.json()) as Record<string, unknown>;
     expect(Array.isArray(data.events)).toBe(true);
-    expect(data.events).toHaveLength(1);
+    expect(data.events as any[]).toHaveLength(1);
   });
 
   it("does NOT fetch events without ?events=true", async () => {
@@ -399,7 +399,7 @@ describe("PATCH /api/seasons/[id]", () => {
     const response = await PATCH(event);
 
     expect(response.status).toBe(200);
-    const data = await response.json();
+    const data = (await response.json()) as Record<string, unknown>;
     expect(data.name).toBe("Spring 2027");
   });
 
@@ -423,7 +423,7 @@ describe("PATCH /api/seasons/[id]", () => {
       expect.objectContaining({ start_date: "2027-03-01" }),
       expect.anything(),
     );
-    const data = await response.json();
+    const data = (await response.json()) as Record<string, unknown>;
     expect(data.start_date).toBe("2027-03-01");
   });
 
@@ -456,7 +456,7 @@ describe("PATCH /api/seasons/[id]", () => {
     const response = await PATCH(event);
 
     expect(response.status).toBe(400);
-    const data = await response.json();
+    const data = (await response.json()) as Record<string, unknown>;
     expect(data.error).toContain("YYYY-MM-DD");
   });
 
@@ -532,7 +532,7 @@ describe("DELETE /api/seasons/[id]", () => {
       "season-1",
       expect.anything(),
     );
-    const data = await response.json();
+    const data = (await response.json()) as Record<string, unknown>;
     expect(data.success).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- Remove stale `roles` property from `CreateInviteInput` calls in org-id-not-null tests (2 errors)
- Add `as Record<string, unknown>` type assertions for `response.json()` in seasons tests (13 errors)
- Wrap `MaybePromise<Response>` with `Promise.resolve()` for `.catch()` in login tests (3 errors, 2 implicit any)
- Widen mock cast via `unknown` for incomplete `RequestEvent` in logout tests (2 errors)

All 1377 tests pass. `pnpm check` now reports 0 errors.

## Test plan
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm test` — 1377 passed, 0 failed